### PR TITLE
Set build to Java7 and remove Java8 JDK usage from tests. (Supporting…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,9 @@ sourceSets {
     }
 }
 
+targetCompatibility = '1.7'
+sourceCompatibility = '1.7'
+
 task carrotJar(type: Jar) {
 }
 

--- a/src/test/java/au/com/codeka/carrot/CarrotEngineTest.java
+++ b/src/test/java/au/com/codeka/carrot/CarrotEngineTest.java
@@ -3,7 +3,6 @@ package au.com.codeka.carrot;
 import au.com.codeka.carrot.resource.ResourceLocater;
 import au.com.codeka.carrot.resource.ResourceName;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -11,6 +10,7 @@ import org.junit.runners.JUnit4;
 import javax.annotation.Nullable;
 import java.io.Reader;
 import java.io.StringReader;
+import java.util.HashMap;
 import java.util.Map;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -32,7 +32,7 @@ public class CarrotEngineTest {
 
   @Test
   public void testIfTag() {
-    assertThat(render("foo{% if a == 0 %}bar{% end %}baz", ImmutableMap.of("a", 0L))).isEqualTo("foobarbaz");
+    assertThat(render("foo{% if a == 0 %}bar{% end %}baz", ImmutableMap.<String, Object>of("a", 0L))).isEqualTo("foobarbaz");
   }
 
   @Test
@@ -49,21 +49,28 @@ public class CarrotEngineTest {
   @Test
   public void testAutoEscape() {
     CarrotEngine engine = createEngine();
-    assertThat(render(engine, "{{ \"Some <b>HTML</b> here\" }}", Maps.newHashMap()))
+    assertThat(render(engine, "{{ \"Some <b>HTML</b> here\" }}", new HashMap<String, Object>()))
         .isEqualTo("Some &lt;b&gt;HTML&lt;/b&gt; here");
 
     engine.getConfig().setAutoEscape(false);
-    assertThat(render(engine, "{{ \"Some <b>HTML</b> here\" }}", Maps.newHashMap()))
+    assertThat(render(engine, "{{ \"Some <b>HTML</b> here\" }}", new HashMap<String, Object>()))
         .isEqualTo("Some <b>HTML</b> here");
 
     engine.getConfig().setAutoEscape(true);
-    assertThat(render(engine, "{{ \"Some <b>HTML</b> here\" }}", Maps.newHashMap()))
+    assertThat(render(engine, "{{ \"Some <b>HTML</b> here\" }}", new HashMap<String, Object>()))
         .isEqualTo("Some &lt;b&gt;HTML&lt;/b&gt; here");
   }
 
   private CarrotEngine createEngine() {
     CarrotEngine engine = new CarrotEngine();
-    engine.getConfig().setLogger((level, msg) -> System.err.println(msg));
+    engine.getConfig().setLogger(new Configuration.Logger()
+    {
+      @Override
+      public void print(int level, String msg)
+      {
+        System.err.println(msg);
+      }
+    });
     return engine;
   }
 

--- a/src/test/java/au/com/codeka/carrot/expr/FunctionTest.java
+++ b/src/test/java/au/com/codeka/carrot/expr/FunctionTest.java
@@ -5,12 +5,12 @@ import au.com.codeka.carrot.Configuration;
 import au.com.codeka.carrot.Scope;
 import au.com.codeka.carrot.resource.ResourcePointer;
 import au.com.codeka.carrot.util.LineReader;
-import com.google.common.collect.Maps;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.io.StringReader;
+import java.util.HashMap;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
@@ -24,7 +24,7 @@ public class FunctionTest {
   public void testMethodNotFound() {
     Function f = new Function.Builder(new Identifier(new Token(TokenType.IDENTIFIER, "foo"))).build();
     try {
-      f.evaluate(new Object(), new Configuration(), new Scope(Maps.newHashMap()));
+      f.evaluate(new Object(), new Configuration(), new Scope(new HashMap<String, Object>()));
       fail("CarrotException expected.");
     } catch (CarrotException e) {
       assertThat(e.getMessage()).isEqualTo("No matching method 'foo' found on class java.lang.Object, candidates: []");
@@ -38,7 +38,7 @@ public class FunctionTest {
         .build();
 
     try {
-      f.evaluate(new FooWithTwoArgs(), new Configuration(), new Scope(Maps.newHashMap()));
+      f.evaluate(new FooWithTwoArgs(), new Configuration(), new Scope(new HashMap<String, Object>()));
       fail("CarrotException expected.");
     } catch (CarrotException e) {
       assertThat(e.getMessage())
@@ -55,7 +55,7 @@ public class FunctionTest {
         .build();
 
     try {
-      f.evaluate(new FooWithTwoArgs(), new Configuration(), new Scope(Maps.newHashMap()));
+      f.evaluate(new FooWithTwoArgs(), new Configuration(), new Scope(new HashMap<String, Object>()));
       fail("CarrotException expected.");
     } catch (CarrotException e) {
       assertThat(e.getMessage())

--- a/src/test/java/au/com/codeka/carrot/expr/VariableTest.java
+++ b/src/test/java/au/com/codeka/carrot/expr/VariableTest.java
@@ -72,7 +72,14 @@ public class VariableTest {
 
   private Configuration createConfig() {
     Configuration config = new Configuration();
-    config.setLogger((level, msg) -> System.err.println(msg));
+    config.setLogger(new Configuration.Logger()
+    {
+      @Override
+      public void print(int level, String msg)
+      {
+        System.err.println(msg);
+      }
+    });
     return config;
   }
 

--- a/src/test/java/au/com/codeka/carrot/tag/ExtendsTagTest.java
+++ b/src/test/java/au/com/codeka/carrot/tag/ExtendsTagTest.java
@@ -1,8 +1,8 @@
 package au.com.codeka.carrot.tag;
 
 import au.com.codeka.carrot.CarrotEngine;
-import au.com.codeka.carrot.CarrotEngineTest;
 import au.com.codeka.carrot.CarrotException;
+import au.com.codeka.carrot.Configuration;
 import au.com.codeka.carrot.resource.MemoryResourceLocator;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,7 +26,7 @@ public class ExtendsTagTest {
         "skeleton", "Hello{% block \"foo\" %}blah blah{% end %}World",
         "index", "{% extends \"skeleton\" %}{% block \"foo\" %}yada yada{% end %}"
       );
-    String result = render(engine, "index", new TreeMap<>());
+    String result = render(engine, "index", new TreeMap<String, Object>());
     assertThat(result).isEqualTo("Helloyada yadaWorld");
   }
 
@@ -36,7 +36,7 @@ public class ExtendsTagTest {
         "skeleton", "Hello{% block \"foo\" %}blah blah{% endblock %}World{% block \"bar\" %}{% endblock %}",
         "index", "{% extends \"skeleton\" %}{% block \"foo\" %}yada yada{% end %}{% block \"bar\" %}stuff{% endblock %}"
     );
-    String result = render(engine, "index", new TreeMap<>());
+    String result = render(engine, "index", new TreeMap<String, Object>());
     assertThat(result).isEqualTo("Helloyada yadaWorldstuff");
   }
 
@@ -46,7 +46,7 @@ public class ExtendsTagTest {
         "skeleton", "Hello{% block \"foo\" %}blah blah{% end %}World",
         "index", "{% extends \"skeleton\" %}"
     );
-    String result = render(engine, "index", new TreeMap<>());
+    String result = render(engine, "index", new TreeMap<String, Object>());
     assertThat(result).isEqualTo("Helloblah blahWorld");
   }
 
@@ -56,7 +56,7 @@ public class ExtendsTagTest {
         "index", "{% extends \"skeleton\" %}"
     );
     try {
-      engine.process("index", new TreeMap<>());
+      engine.process("index", new TreeMap<String, Object>());
       fail("Expected CarrotException.");
     } catch (CarrotException e) {
       assertThat(e.getMessage())
@@ -74,7 +74,14 @@ public class ExtendsTagTest {
 
   private CarrotEngine createEngine(String... nameValues) {
     CarrotEngine engine = new CarrotEngine();
-    engine.getConfig().setLogger((level, msg) -> System.err.println(msg));
+    engine.getConfig().setLogger(new Configuration.Logger()
+    {
+      @Override
+      public void print(int level, String msg)
+      {
+        System.err.println(msg);
+      }
+    });
     engine.getConfig().setResourceLocater(createResources(nameValues));
     return engine;
   }

--- a/src/test/java/au/com/codeka/carrot/tag/ForTagTest.java
+++ b/src/test/java/au/com/codeka/carrot/tag/ForTagTest.java
@@ -2,6 +2,7 @@ package au.com.codeka.carrot.tag;
 
 import au.com.codeka.carrot.CarrotEngine;
 import au.com.codeka.carrot.CarrotException;
+import au.com.codeka.carrot.Configuration;
 import au.com.codeka.carrot.resource.MemoryResourceLocator;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -80,7 +81,14 @@ public class ForTagTest {
 
   private String render(String content, @Nullable Map<String, Object> bindings) throws CarrotException {
     CarrotEngine engine = new CarrotEngine();
-    engine.getConfig().setLogger((level, msg) -> System.err.println(msg));
+    engine.getConfig().setLogger(new Configuration.Logger()
+    {
+      @Override
+      public void print(int level, String msg)
+      {
+        System.err.println(msg);
+      }
+    });
 
     Map<String, String> resources = new TreeMap<>();
     resources.put("index", content);

--- a/src/test/java/au/com/codeka/carrot/util/RenderHelper.java
+++ b/src/test/java/au/com/codeka/carrot/util/RenderHelper.java
@@ -15,9 +15,15 @@ import java.util.TreeMap;
 public class RenderHelper {
   public static String render(String content, Object... bindings) throws CarrotException {
     CarrotEngine engine = new CarrotEngine();
-    engine.getConfig().setLogger((level, msg) -> {
-      if (level > Configuration.Logger.LEVEL_DEBUG) {
-        System.err.println(msg);
+    engine.getConfig().setLogger(new Configuration.Logger()
+    {
+      @Override
+      public void print(int level, String msg)
+      {
+        if (level > Configuration.Logger.LEVEL_DEBUG)
+        {
+          System.err.println(msg);
+        }
       }
     });
 


### PR DESCRIPTION
… Android requires Java7)

---

Hi,

Continuing https://github.com/codeka/carrot/issues/1, this pull request converts the test code as welll to use only Java7 and sets the java build version in gradle so that the jars uploaded to maven or built with jitpack can be used directly in Android projects. 
(jitpack builds java projects with Java8 by default if compatibility versions are not specified).
 
With this we could avoid the need to build the jars manually for ourselves each time we need an update.