### PR TITLE
Replace Bindings map by dedicate `Bindings` interface. This allows to…

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,19 +57,18 @@ index.html:
 
 Finally to process a template, you use the `process` method:
 
-    Map<String, Object> bindings = new TreeMap<>();
-    System.out.println(engine.process("index.html", bindings));
+    System.out.println(engine.process("index.html", new EmptyBindings()));
 
 Now how do you actually pass data from your application to the template? That's what the bindings are for. Say you have
 the following in your template:
 
     <p>Hello, {{ name }}!</p>
 
-You'd pass data to that via a binding, like so:
+You'd pass data to that via `Bindings`, like so:
 
     Map<String, Object> bindings = new TreeMap<>();
     bindings.put("name", "Dean");
-    System.out.println(engine.process("index.html", bindings));
+    System.out.println(engine.process("index.html", new MapBindings(bindings)));
 
 Documentation
 =============

--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,10 @@ repositories {
 
 dependencies {
     compile 'com.google.code.findbugs:jsr305:3.0.1'
+    compileOnly 'org.json:json:20170516'
     testCompile 'junit:junit:4.12'
     testCompile 'com.google.truth:truth:0.31'
+    testCompile 'org.json:json:20170516'
 }
 
 sourceSets {

--- a/src/docs/java/au/com/codeka/carrot/BuildDocs.java
+++ b/src/docs/java/au/com/codeka/carrot/BuildDocs.java
@@ -1,5 +1,6 @@
 package au.com.codeka.carrot;
 
+import au.com.codeka.carrot.bindings.MapBindings;
 import au.com.codeka.carrot.resource.FileResourceLocater;
 
 import java.io.File;
@@ -56,7 +57,7 @@ class BuildDocs {
         }
         bindings.put("basePath", basePath);
 
-        String contents = engine.process(inputFile, bindings);
+        String contents = engine.process(inputFile, new MapBindings(bindings));
         Files.write(new File(outputFile).toPath(), contents.getBytes("UTF-8"));
       } catch (CarrotException | IOException e) {
         e.printStackTrace(System.err);

--- a/src/main/java/au/com/codeka/carrot/Bindings.java
+++ b/src/main/java/au/com/codeka/carrot/Bindings.java
@@ -1,0 +1,28 @@
+package au.com.codeka.carrot;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * The Bindings of a template when rendered.
+ *
+ * @author marten
+ */
+public interface Bindings {
+
+    /**
+     * Returns a value for the given key or {@code null} if no such key exists in these Bindings.
+     *
+     * @param key The key to resolve.
+     * @return An {@link Object} or {@code null}.
+     */
+    @Nullable
+    Object resolve(@Nonnull String key);
+
+    /**
+     * Returns whether these Bindings contain any values.
+     *
+     * @return {@code true} if these Bindings are empty, {@code false} if there is at least one value.
+     */
+    boolean isEmpty();
+}

--- a/src/main/java/au/com/codeka/carrot/CarrotEngine.java
+++ b/src/main/java/au/com/codeka/carrot/CarrotEngine.java
@@ -1,19 +1,18 @@
 package au.com.codeka.carrot;
 
+import au.com.codeka.carrot.bindings.SingletonBindings;
 import au.com.codeka.carrot.helpers.HtmlHelper;
-import au.com.codeka.carrot.util.LineReader;
-import au.com.codeka.carrot.tmpl.parse.Tokenizer;
 import au.com.codeka.carrot.resource.ResourceLocater;
 import au.com.codeka.carrot.resource.ResourceName;
 import au.com.codeka.carrot.tmpl.Node;
 import au.com.codeka.carrot.tmpl.TemplateParser;
+import au.com.codeka.carrot.tmpl.parse.Tokenizer;
+import au.com.codeka.carrot.util.LineReader;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * {@link CarrotEngine} is the root of the carrot system. You create an instance of this, make it global or static,
@@ -21,7 +20,7 @@ import java.util.Map;
  */
 public class CarrotEngine {
   private final Configuration config;
-  private final Map<String, Object> globalBindings;
+  private final Bindings globalBindings;
   private final ParseCache parseCache;
   private final TemplateParser templateParser;
 
@@ -43,11 +42,9 @@ public class CarrotEngine {
    */
   public CarrotEngine(Configuration config) {
     this.config = config;
-    this.globalBindings = new HashMap<>();
+    this.globalBindings = new SingletonBindings("html", new HtmlHelper());
     this.parseCache = new ParseCache(config);
     this.templateParser = new TemplateParser(config);
-
-    globalBindings.put("html", new HtmlHelper());
   }
 
   /**
@@ -62,7 +59,7 @@ public class CarrotEngine {
    * @return A map of the global variables. These bindings will be accessible in all templates processed by this
    * {@link CarrotEngine}.
    */
-  public Map<String, Object> getGlobalBindings() {
+  public Bindings globalBindings() {
     return globalBindings;
   }
 
@@ -107,7 +104,7 @@ public class CarrotEngine {
   public void process(
       Writer writer,
       String templateFile,
-      @Nullable Map<String, Object> bindings) throws CarrotException {
+      @Nullable Bindings bindings) throws CarrotException {
     ResourceName resourceName = config.getResourceLocater().findResource(templateFile);
 
     Scope scope = new Scope(globalBindings);
@@ -128,7 +125,7 @@ public class CarrotEngine {
    *
    * @throws CarrotException Thrown if any errors occur.
    */
-  public String process(String templateFile, @Nullable Map<String, Object> bindings) throws CarrotException {
+  public String process(String templateFile, @Nullable Bindings bindings) throws CarrotException {
     StringWriter writer = new StringWriter();
     process(writer, templateFile, bindings);
     return writer.getBuffer().toString();

--- a/src/main/java/au/com/codeka/carrot/Scope.java
+++ b/src/main/java/au/com/codeka/carrot/Scope.java
@@ -1,5 +1,7 @@
 package au.com.codeka.carrot;
 
+import au.com.codeka.carrot.bindings.Composite;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.*;
@@ -11,14 +13,14 @@ import static au.com.codeka.carrot.util.Preconditions.checkNotNull;
  * down a node, you can push new bindings onto the stack and those will be the first one searched for a variable.
  */
 public class Scope {
-  private final Deque<Map<String, Object>> stack = new ArrayDeque<>();
+  private final Deque<Bindings> stack = new ArrayDeque<>();
 
   /**
    * Create a new {@link Scope}, with the given initial set of "global" bindings.
    *
    * @param globalBindings A set of "global" bindings that you want first on the stack.
    */
-  public Scope(Map<String, Object> globalBindings) {
+  public Scope(Bindings globalBindings) {
     stack.add(globalBindings);
   }
 
@@ -27,7 +29,7 @@ public class Scope {
    *
    * @param bindings The bindings to push.
    */
-  public void push(Map<String, Object> bindings) {
+  public void push(Bindings bindings) {
     stack.push(bindings);
   }
 
@@ -36,11 +38,15 @@ public class Scope {
     stack.pop();
   }
 
-  /** @return The current bindings off the top of the stack. */
-  public Map<String, Object> peek() {
-    return stack.peek();
-  }
 
+  /**
+   * Extend the current bindings with the given one.
+   *
+   * @param bindings The new {@link Bindings}.
+   */
+  public void extendCurrent(Bindings bindings) {
+    stack.push(new Composite(bindings, stack.pop()));
+  }
   /**
    * Resolve the given named variable from the stack of bindings, most recently-pushed to last.
    *
@@ -51,8 +57,8 @@ public class Scope {
   public Object resolve(@Nonnull String name) {
     checkNotNull(name);
 
-    for (Map<String, Object> bindings : stack) {
-      Object value = bindings.get(name);
+    for (Bindings bindings : stack) {
+      Object value = bindings.resolve(name);
       if (value != null) {
         return value;
       }

--- a/src/main/java/au/com/codeka/carrot/bindings/Composite.java
+++ b/src/main/java/au/com/codeka/carrot/bindings/Composite.java
@@ -1,0 +1,66 @@
+package au.com.codeka.carrot.bindings;
+
+import au.com.codeka.carrot.Bindings;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+
+
+/**
+ * Composite {@link Bindings} which combines the values of other {@link Bindings} into one. Note that the order is important in case two bindings contain a
+ * value with the same key. In such case the first binding wins.
+ * <p>
+ * To avoid conflicts, you can insert "prefix" sub-bindings like so
+ * <p>
+ * <pre>{@code
+ * new Composite(
+ *    new MapBindings(map),
+ *    new SingletonBindings("$json", new JsonObjectBindings(jsonObject));
+ * )
+ * }</pre>
+ * <p>
+ * Given that the key {@code "key"} exists in both, the {@code map} and the {@code jsonObject} you would access them like
+ * <p>
+ * <pre><code>
+ * Map key: {{ key }}
+ * JSON key: {{ $json.key }}
+ * </code></pre>
+ *
+ * @author Marten Gajda
+ */
+public final class Composite implements Bindings {
+    private final Iterable<Bindings> bindingsIterable;
+
+
+    public Composite(Bindings... bindings) {
+        this(Arrays.asList(bindings));
+    }
+
+
+    public Composite(Iterable<Bindings> bindingsIterable) {
+        this.bindingsIterable = bindingsIterable;
+    }
+
+
+    @Override
+    public Object resolve(@Nonnull String key) {
+        for (Bindings bindings : bindingsIterable) {
+            Object value = bindings.resolve(key);
+            if (value != null) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+
+    @Override
+    public boolean isEmpty() {
+        for (Bindings bindings : bindingsIterable) {
+            if (!bindings.isEmpty()) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/au/com/codeka/carrot/bindings/EmptyBindings.java
+++ b/src/main/java/au/com/codeka/carrot/bindings/EmptyBindings.java
@@ -1,0 +1,24 @@
+package au.com.codeka.carrot.bindings;
+
+import au.com.codeka.carrot.Bindings;
+
+import javax.annotation.Nonnull;
+
+
+/**
+ * {@link Bindings} without any values.
+ *
+ * @author Marten Gajda
+ */
+public final class EmptyBindings implements Bindings {
+    @Override
+    public Object resolve(@Nonnull String key) {
+        return null;
+    }
+
+
+    @Override
+    public boolean isEmpty() {
+        return true;
+    }
+}

--- a/src/main/java/au/com/codeka/carrot/bindings/EntryBindings.java
+++ b/src/main/java/au/com/codeka/carrot/bindings/EntryBindings.java
@@ -1,0 +1,46 @@
+package au.com.codeka.carrot.bindings;
+
+import au.com.codeka.carrot.Bindings;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+
+/**
+ * {@link Bindings} for {@link java.util.Map.Entry}.
+ * <p>
+ * It provides access to key and value of an Entry like so
+ * <pre><code>
+ *    {{ item.key }} -&gt; {{ item.value }}
+ * </code></pre>
+ * <p>
+ * Note: strictly spoken this would not be necessary, because the reflection function resolution would do the
+ * same (by calling {@link Map.Entry#getKey()} and {@link Map.Entry#getValue()}. A dedicated {@link Bindings} class is,
+ * however, considered better design and certainly faster.
+ *
+ * @author Marten Gajda
+ */
+public final class EntryBindings implements Bindings {
+
+    private final Map.Entry<String, Object> entry;
+
+    public EntryBindings(Map.Entry<String, Object> entry) {
+        this.entry = entry;
+    }
+
+    @Override
+    public Object resolve(@Nonnull String key) {
+        switch (key) {
+            case "key":
+                return entry.getKey();
+            case "value":
+                return entry.getValue();
+            default:
+                return null;
+        }
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return false;
+    }
+}

--- a/src/main/java/au/com/codeka/carrot/bindings/JsonArrayBindings.java
+++ b/src/main/java/au/com/codeka/carrot/bindings/JsonArrayBindings.java
@@ -1,0 +1,58 @@
+package au.com.codeka.carrot.bindings;
+
+import au.com.codeka.carrot.Bindings;
+import au.com.codeka.carrot.ValueHelper;
+import org.json.JSONArray;
+
+import javax.annotation.Nonnull;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+
+/**
+ * {@link Bindings} based on the values in a {@link JSONArray}.
+ *
+ * @author Marten Gajda
+ */
+public final class JsonArrayBindings implements Bindings, Iterable {
+    private final JSONArray jsonArray;
+
+
+    public JsonArrayBindings(JSONArray jsonArray) {
+        this.jsonArray = jsonArray;
+    }
+
+
+    @Override
+    public Object resolve(@Nonnull String key) {
+        return ValueHelper.jsonHelper(jsonArray.get(Integer.parseInt(key)));
+    }
+
+
+    @Override
+    public boolean isEmpty() {
+        return jsonArray.length() == 0;
+    }
+
+
+    @Override
+    public Iterator iterator() {
+        return new Iterator() {
+            int index = 0;
+
+            @Override
+            public boolean hasNext() {
+                return index < jsonArray.length();
+            }
+
+
+            @Override
+            public Object next() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException("No further elements to iterate");
+                }
+                return ValueHelper.jsonHelper(jsonArray.get(index++));
+            }
+        };
+    }
+}

--- a/src/main/java/au/com/codeka/carrot/bindings/JsonObjectBindings.java
+++ b/src/main/java/au/com/codeka/carrot/bindings/JsonObjectBindings.java
@@ -1,0 +1,64 @@
+package au.com.codeka.carrot.bindings;
+
+import au.com.codeka.carrot.Bindings;
+import au.com.codeka.carrot.ValueHelper;
+import org.json.JSONObject;
+
+import javax.annotation.Nonnull;
+import java.util.AbstractMap;
+import java.util.Iterator;
+
+
+/**
+ * {@link Bindings} based on the values in a {@link JSONObject}.
+ *
+ * @author Marten Gajda
+ */
+public final class JsonObjectBindings implements Bindings, Iterable {
+    private final JSONObject jsonObject;
+
+
+    public JsonObjectBindings(JSONObject jsonObject) {
+        this.jsonObject = jsonObject;
+    }
+
+
+    @Override
+    public Object resolve(@Nonnull String key) {
+        return ValueHelper.jsonHelper(jsonObject.opt(key));
+    }
+
+
+    @Override
+    public boolean isEmpty() {
+        return jsonObject.length() == 0;
+    }
+
+
+    @Override
+    public Iterator iterator() {
+        final Iterator<String> keys = jsonObject.keys();
+
+        // return an iterator of Map Entries which allows iterating json objects like this:
+        // {% for item in json %}
+        //    {{ item.key }} -> {{ item.value }}
+        // {% end %}
+        return new Iterator() {
+            @Override
+            public boolean hasNext() {
+                return keys.hasNext();
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException("Remove not supported.");
+            }
+
+            @Override
+            public Object next() {
+                final String key = keys.next();
+                return new EntryBindings(new AbstractMap.SimpleImmutableEntry<>(key, ValueHelper.jsonHelper(jsonObject.opt(key))));
+            }
+        };
+    }
+}

--- a/src/main/java/au/com/codeka/carrot/bindings/MapBindings.java
+++ b/src/main/java/au/com/codeka/carrot/bindings/MapBindings.java
@@ -1,0 +1,33 @@
+package au.com.codeka.carrot.bindings;
+
+import au.com.codeka.carrot.Bindings;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+
+
+/**
+ * {@link Bindings} based on the content of a {@link Map}
+ *
+ * @author Marten Gajda
+ */
+public final class MapBindings implements Bindings {
+    private final Map<String, Object> contextMap;
+
+
+    public MapBindings(Map<String, Object> contextMap) {
+        this.contextMap = contextMap;
+    }
+
+
+    @Override
+    public Object resolve(@Nonnull String key) {
+        return contextMap.get(key);
+    }
+
+
+    @Override
+    public boolean isEmpty() {
+        return contextMap.isEmpty();
+    }
+}

--- a/src/main/java/au/com/codeka/carrot/bindings/SingletonBindings.java
+++ b/src/main/java/au/com/codeka/carrot/bindings/SingletonBindings.java
@@ -1,0 +1,34 @@
+package au.com.codeka.carrot.bindings;
+
+import au.com.codeka.carrot.Bindings;
+
+import javax.annotation.Nonnull;
+
+
+/**
+ * {@link Bindings} with exactly one value.
+ *
+ * @author Marten Gajda
+ */
+public final class SingletonBindings implements Bindings {
+    private final String key;
+    private final Object value;
+
+
+    public SingletonBindings(@Nonnull String key, Object value) {
+        this.key = key;
+        this.value = value;
+    }
+
+
+    @Override
+    public Object resolve(@Nonnull String key) {
+        return this.key.equals(key) ? value : null;
+    }
+
+
+    @Override
+    public boolean isEmpty() {
+        return false;
+    }
+}

--- a/src/main/java/au/com/codeka/carrot/expr/Variable.java
+++ b/src/main/java/au/com/codeka/carrot/expr/Variable.java
@@ -1,5 +1,6 @@
 package au.com.codeka.carrot.expr;
 
+import au.com.codeka.carrot.Bindings;
 import au.com.codeka.carrot.CarrotException;
 import au.com.codeka.carrot.Configuration;
 import au.com.codeka.carrot.Scope;
@@ -76,6 +77,9 @@ public class Variable {
     } else if (value instanceof Map) {
       Map map = (Map) value;
       return map.get(accessor);
+    } else if (value instanceof Bindings) {
+      Bindings bindings = (Bindings) value;
+      return bindings.resolve(accessor.toString());
     } else if (value instanceof List) {
       List list = (List) value;
       return list.get(ValueHelper.toNumber(accessor).intValue());

--- a/src/main/java/au/com/codeka/carrot/tag/ExtendsTag.java
+++ b/src/main/java/au/com/codeka/carrot/tag/ExtendsTag.java
@@ -2,6 +2,7 @@ package au.com.codeka.carrot.tag;
 
 import au.com.codeka.carrot.CarrotEngine;
 import au.com.codeka.carrot.CarrotException;
+import au.com.codeka.carrot.bindings.SingletonBindings;
 import au.com.codeka.carrot.expr.Expression;
 import au.com.codeka.carrot.expr.StatementParser;
 import au.com.codeka.carrot.Scope;
@@ -85,9 +86,7 @@ public class ExtendsTag extends Tag {
     // TODO: we should locate the resource with the current parent.
     ResourceName resourceName = engine.getConfig().getResourceLocater().findResource(null, skeletonName);
 
-    Map<String, Object> context = new HashMap<>();
-    context.put("__blocks", blockTags);
-    scope.push(context);
+    scope.push(new SingletonBindings("__blocks", blockTags));
     engine.process(writer, resourceName, scope);
     scope.pop();
   }

--- a/src/main/java/au/com/codeka/carrot/tag/ForTag.java
+++ b/src/main/java/au/com/codeka/carrot/tag/ForTag.java
@@ -4,6 +4,7 @@ import au.com.codeka.carrot.CarrotEngine;
 import au.com.codeka.carrot.CarrotException;
 import au.com.codeka.carrot.Scope;
 import au.com.codeka.carrot.ValueHelper;
+import au.com.codeka.carrot.bindings.MapBindings;
 import au.com.codeka.carrot.expr.Expression;
 import au.com.codeka.carrot.expr.Identifier;
 import au.com.codeka.carrot.expr.StatementParser;
@@ -62,7 +63,7 @@ public class ForTag extends Tag {
       loop.put("length", objects.size());
       context.put("loop", loop);
 
-      scope.push(context);
+      scope.push(new MapBindings(context));
       tagNode.renderChildren(engine, writer, scope);
       scope.pop();
     }

--- a/src/main/java/au/com/codeka/carrot/tag/SetTag.java
+++ b/src/main/java/au/com/codeka/carrot/tag/SetTag.java
@@ -3,6 +3,7 @@ package au.com.codeka.carrot.tag;
 import au.com.codeka.carrot.CarrotEngine;
 import au.com.codeka.carrot.CarrotException;
 import au.com.codeka.carrot.Scope;
+import au.com.codeka.carrot.bindings.SingletonBindings;
 import au.com.codeka.carrot.expr.Expression;
 import au.com.codeka.carrot.expr.Identifier;
 import au.com.codeka.carrot.expr.StatementParser;
@@ -37,6 +38,6 @@ public class SetTag extends Tag {
     StringWriter stringWriter = new StringWriter();
     tagNode.renderChildren(engine, stringWriter, scope);
 
-    scope.peek().put(identifier.evaluate(), stringWriter.toString());
+    scope.extendCurrent(new SingletonBindings(identifier.evaluate(), stringWriter.toString()));
   }
 }

--- a/src/test/java/au/com/codeka/carrot/bindings/CompositeTest.java
+++ b/src/test/java/au/com/codeka/carrot/bindings/CompositeTest.java
@@ -1,0 +1,36 @@
+package au.com.codeka.carrot.bindings;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * @author marten
+ */
+public class CompositeTest {
+    @Test
+    public void testResolved() throws Exception {
+        assertThat(new Composite().resolve("key"), CoreMatchers.nullValue());
+        assertThat(new Composite(new EmptyBindings()).resolve("key"), CoreMatchers.nullValue());
+        assertThat(new Composite(new EmptyBindings(), new EmptyBindings()).resolve("key"), CoreMatchers.nullValue());
+
+        assertThat(new Composite(new SingletonBindings("key", "value")).resolve("key"), CoreMatchers.<Object>is("value"));
+        assertThat(new Composite(new EmptyBindings(), new SingletonBindings("key", "value")).resolve("key"), CoreMatchers.<Object>is("value"));
+        assertThat(new Composite(new SingletonBindings("key1", "value1"), new SingletonBindings("key2", "value2")).resolve("key1"), CoreMatchers.<Object>is("value1"));
+        assertThat(new Composite(new SingletonBindings("key1", "value1"), new SingletonBindings("key2", "value2")).resolve("key2"), CoreMatchers.<Object>is("value2"));
+    }
+
+
+    @Test
+    public void testIsEmpty() throws Exception {
+        assertThat(new Composite().isEmpty(), CoreMatchers.is(true));
+        assertThat(new Composite(new EmptyBindings()).isEmpty(), CoreMatchers.is(true));
+        assertThat(new Composite(new EmptyBindings(), new EmptyBindings()).isEmpty(), CoreMatchers.is(true));
+
+        assertThat(new Composite(new EmptyBindings(), new SingletonBindings("key", "value")).isEmpty(), CoreMatchers.is(false));
+        assertThat(new Composite(new SingletonBindings("key1", "value1"), new SingletonBindings("key2", "value2")).isEmpty(), CoreMatchers.is(false));
+    }
+
+}

--- a/src/test/java/au/com/codeka/carrot/bindings/EmptyBindingsTest.java
+++ b/src/test/java/au/com/codeka/carrot/bindings/EmptyBindingsTest.java
@@ -1,0 +1,24 @@
+package au.com.codeka.carrot.bindings;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * @author marten
+ */
+public class EmptyBindingsTest {
+    @Test
+    public void testResolved() throws Exception {
+        assertThat(new EmptyBindings().resolve("abc"), CoreMatchers.nullValue());
+    }
+
+
+    @Test
+    public void testIsEmpty() throws Exception {
+        assertThat(new EmptyBindings().isEmpty(), CoreMatchers.is(true));
+    }
+
+}

--- a/src/test/java/au/com/codeka/carrot/bindings/EntryBindingsTest.java
+++ b/src/test/java/au/com/codeka/carrot/bindings/EntryBindingsTest.java
@@ -1,0 +1,25 @@
+package au.com.codeka.carrot.bindings;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+import java.util.AbstractMap;
+
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Marten Gajda
+ */
+public class EntryBindingsTest {
+    @Test
+    public void testResolve() throws Exception {
+        assertThat(new EntryBindings(new AbstractMap.SimpleImmutableEntry<String, Object>("entry_key", "entry_value")).resolve("key"), CoreMatchers.<Object>is("entry_key"));
+        assertThat(new EntryBindings(new AbstractMap.SimpleImmutableEntry<String, Object>("entry_key", "entry_value")).resolve("value"), CoreMatchers.<Object>is("entry_value"));
+        assertThat(new EntryBindings(new AbstractMap.SimpleImmutableEntry<String, Object>("entry_key", "entry_value")).resolve("other"), CoreMatchers.nullValue());
+    }
+
+    @Test
+    public void testIsEmpty() throws Exception {
+        assertThat(new EntryBindings(new AbstractMap.SimpleImmutableEntry<String, Object>("entry_key", "entry_value")).isEmpty(), CoreMatchers.is(false));
+    }
+}

--- a/src/test/java/au/com/codeka/carrot/bindings/JsonArrayBindingsTest.java
+++ b/src/test/java/au/com/codeka/carrot/bindings/JsonArrayBindingsTest.java
@@ -1,0 +1,46 @@
+package au.com.codeka.carrot.bindings;
+
+import org.hamcrest.CoreMatchers;
+import org.json.JSONArray;
+import org.junit.Test;
+
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * @author marten
+ */
+public class JsonArrayBindingsTest {
+    private final static String JSON_ARRAY = "[\n" +
+            "  \"value\",\n" +
+            "  2,\n" +
+            "  true,\n" +
+            "  [\n" +
+            "    \"a\",\n" +
+            "    \"b\"\n" +
+            "  ],\n" +
+            "  {\n" +
+            "    \"inner\": \"value\"\n" +
+            "  },\n" +
+            "  null\n" +
+            "]";
+
+
+    @Test
+    public void testResolved() throws Exception {
+        assertThat(new JsonArrayBindings(new JSONArray(JSON_ARRAY)).resolve("0"), CoreMatchers.<Object>is("value"));
+        assertThat(new JsonArrayBindings(new JSONArray(JSON_ARRAY)).resolve("1"), CoreMatchers.<Object>is(2));
+        assertThat(new JsonArrayBindings(new JSONArray(JSON_ARRAY)).resolve("2"), CoreMatchers.<Object>is(true));
+        assertThat(new JsonArrayBindings(new JSONArray(JSON_ARRAY)).resolve("3"), CoreMatchers.instanceOf(JsonArrayBindings.class));
+        assertThat(new JsonArrayBindings(new JSONArray(JSON_ARRAY)).resolve("4"), CoreMatchers.instanceOf(JsonObjectBindings.class));
+        assertThat(new JsonArrayBindings(new JSONArray(JSON_ARRAY)).resolve("5"), CoreMatchers.nullValue());
+    }
+
+
+    @Test
+    public void testIsEmpty() throws Exception {
+        assertThat(new JsonArrayBindings(new JSONArray()).isEmpty(), CoreMatchers.is(true));
+        assertThat(new JsonArrayBindings(new JSONArray(JSON_ARRAY)).isEmpty(), CoreMatchers.is(false));
+    }
+
+}

--- a/src/test/java/au/com/codeka/carrot/bindings/JsonObjectBindingsTest.java
+++ b/src/test/java/au/com/codeka/carrot/bindings/JsonObjectBindingsTest.java
@@ -1,0 +1,45 @@
+package au.com.codeka.carrot.bindings;
+
+import org.hamcrest.CoreMatchers;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * @author marten
+ */
+public class JsonObjectBindingsTest {
+
+
+    private final static String JSON_OBJECT = "{\n" +
+            "  \"key1\": \"value\",\n" +
+            "  \"key2\": 2,\n" +
+            "  \"key3\": true,\n" +
+            "  \"key4\": [\"a\", \"b\"],\n" +
+            "  \"key5\": {\n" +
+            "    \"inner\": \"value\"\n" +
+            "  },\n" +
+            "  \"key6\": null\n" +
+            "}";
+
+
+    @Test
+    public void testResolved() throws Exception {
+        assertThat(new JsonObjectBindings(new JSONObject()).resolve("key"), CoreMatchers.nullValue());
+        assertThat(new JsonObjectBindings(new JSONObject(JSON_OBJECT)).resolve("key1"), CoreMatchers.<Object>is("value"));
+        assertThat(new JsonObjectBindings(new JSONObject(JSON_OBJECT)).resolve("key2"), CoreMatchers.<Object>is(2));
+        assertThat(new JsonObjectBindings(new JSONObject(JSON_OBJECT)).resolve("key3"), CoreMatchers.<Object>is(true));
+        assertThat(new JsonObjectBindings(new JSONObject(JSON_OBJECT)).resolve("key4"), CoreMatchers.instanceOf(JsonArrayBindings.class));
+        assertThat(new JsonObjectBindings(new JSONObject(JSON_OBJECT)).resolve("key5"), CoreMatchers.instanceOf(JsonObjectBindings.class));
+        assertThat(new JsonObjectBindings(new JSONObject(JSON_OBJECT)).resolve("key6"), CoreMatchers.nullValue());
+    }
+
+
+    @Test
+    public void testIsEmpty() throws Exception {
+        assertThat(new JsonObjectBindings(new JSONObject()).isEmpty(), CoreMatchers.is(true));
+        assertThat(new JsonObjectBindings(new JSONObject(JSON_OBJECT)).isEmpty(), CoreMatchers.is(false));
+    }
+}

--- a/src/test/java/au/com/codeka/carrot/bindings/MapBindingsTest.java
+++ b/src/test/java/au/com/codeka/carrot/bindings/MapBindingsTest.java
@@ -1,0 +1,46 @@
+package au.com.codeka.carrot.bindings;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * @author marten
+ */
+public class MapBindingsTest {
+    @Test
+    public void testResolvedEmpty() throws Exception {
+        assertThat(new MapBindings(new HashMap<String, Object>()).resolve("key"), CoreMatchers.nullValue());
+    }
+
+    @Test
+    public void testResolved() throws Exception {
+        Map<String, Object> bindings = new HashMap<>();
+        bindings.put("key1", "value");
+        bindings.put("key2", 1);
+        bindings.put("key3", true);
+
+        assertThat(new MapBindings(bindings).resolve("key1"), CoreMatchers.<Object>is("value"));
+        assertThat(new MapBindings(bindings).resolve("key2"), CoreMatchers.<Object>is(1));
+        assertThat(new MapBindings(bindings).resolve("key3"), CoreMatchers.<Object>is(true));
+    }
+
+
+    @Test
+    public void testIsEmpty() throws Exception {
+        assertThat(new MapBindings(new HashMap<String, Object>()).isEmpty(), CoreMatchers.is(true));
+    }
+
+    @Test
+    public void testIsEmptyNotEmpty() throws Exception {
+        Map<String, Object> bindings = new HashMap<>();
+        bindings.put("key1", "value");
+        assertThat(new MapBindings(bindings).isEmpty(), CoreMatchers.is(false));
+    }
+
+}

--- a/src/test/java/au/com/codeka/carrot/bindings/SingletonBindingsTest.java
+++ b/src/test/java/au/com/codeka/carrot/bindings/SingletonBindingsTest.java
@@ -1,0 +1,25 @@
+package au.com.codeka.carrot.bindings;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * @author marten
+ */
+public class SingletonBindingsTest {
+    @Test
+    public void testResolved() throws Exception {
+        assertThat(new SingletonBindings("key", "value").resolve("key"), CoreMatchers.<Object>is("value"));
+        assertThat(new SingletonBindings("key", "value").resolve("otherkey"), CoreMatchers.nullValue());
+    }
+
+
+    @Test
+    public void testIsEmpty() throws Exception {
+        assertThat(new SingletonBindings("key", "value").isEmpty(), CoreMatchers.is(false));
+    }
+
+}

--- a/src/test/java/au/com/codeka/carrot/expr/FunctionTest.java
+++ b/src/test/java/au/com/codeka/carrot/expr/FunctionTest.java
@@ -3,6 +3,7 @@ package au.com.codeka.carrot.expr;
 import au.com.codeka.carrot.CarrotException;
 import au.com.codeka.carrot.Configuration;
 import au.com.codeka.carrot.Scope;
+import au.com.codeka.carrot.bindings.EmptyBindings;
 import au.com.codeka.carrot.resource.ResourcePointer;
 import au.com.codeka.carrot.util.LineReader;
 import org.junit.Test;
@@ -24,7 +25,7 @@ public class FunctionTest {
   public void testMethodNotFound() {
     Function f = new Function.Builder(new Identifier(new Token(TokenType.IDENTIFIER, "foo"))).build();
     try {
-      f.evaluate(new Object(), new Configuration(), new Scope(new HashMap<String, Object>()));
+      f.evaluate(new Object(), new Configuration(), new Scope(new EmptyBindings()));
       fail("CarrotException expected.");
     } catch (CarrotException e) {
       assertThat(e.getMessage()).isEqualTo("No matching method 'foo' found on class java.lang.Object, candidates: []");
@@ -38,7 +39,7 @@ public class FunctionTest {
         .build();
 
     try {
-      f.evaluate(new FooWithTwoArgs(), new Configuration(), new Scope(new HashMap<String, Object>()));
+      f.evaluate(new FooWithTwoArgs(), new Configuration(), new Scope(new EmptyBindings()));
       fail("CarrotException expected.");
     } catch (CarrotException e) {
       assertThat(e.getMessage())
@@ -55,7 +56,7 @@ public class FunctionTest {
         .build();
 
     try {
-      f.evaluate(new FooWithTwoArgs(), new Configuration(), new Scope(new HashMap<String, Object>()));
+      f.evaluate(new FooWithTwoArgs(), new Configuration(), new Scope(new EmptyBindings()));
       fail("CarrotException expected.");
     } catch (CarrotException e) {
       assertThat(e.getMessage())

--- a/src/test/java/au/com/codeka/carrot/expr/VariableTest.java
+++ b/src/test/java/au/com/codeka/carrot/expr/VariableTest.java
@@ -3,6 +3,7 @@ package au.com.codeka.carrot.expr;
 import au.com.codeka.carrot.CarrotException;
 import au.com.codeka.carrot.Configuration;
 import au.com.codeka.carrot.Scope;
+import au.com.codeka.carrot.bindings.MapBindings;
 import au.com.codeka.carrot.resource.ResourcePointer;
 import au.com.codeka.carrot.util.LineReader;
 import org.junit.Test;
@@ -88,7 +89,7 @@ public class VariableTest {
     for (int i = 0; i < values.length; i += 2) {
       map.put(values[i].toString(), values[i+1]);
     }
-    return new Scope(map);
+    return new Scope(new MapBindings(map));
   }
 
   private Variable parse(String expr) throws CarrotException {

--- a/src/test/java/au/com/codeka/carrot/tag/ExtendsTagTest.java
+++ b/src/test/java/au/com/codeka/carrot/tag/ExtendsTagTest.java
@@ -3,6 +3,8 @@ package au.com.codeka.carrot.tag;
 import au.com.codeka.carrot.CarrotEngine;
 import au.com.codeka.carrot.CarrotException;
 import au.com.codeka.carrot.Configuration;
+import au.com.codeka.carrot.Bindings;
+import au.com.codeka.carrot.bindings.EmptyBindings;
 import au.com.codeka.carrot.resource.MemoryResourceLocator;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,7 +28,7 @@ public class ExtendsTagTest {
         "skeleton", "Hello{% block \"foo\" %}blah blah{% end %}World",
         "index", "{% extends \"skeleton\" %}{% block \"foo\" %}yada yada{% end %}"
       );
-    String result = render(engine, "index", new TreeMap<String, Object>());
+    String result = render(engine, "index", new EmptyBindings());
     assertThat(result).isEqualTo("Helloyada yadaWorld");
   }
 
@@ -36,7 +38,7 @@ public class ExtendsTagTest {
         "skeleton", "Hello{% block \"foo\" %}blah blah{% endblock %}World{% block \"bar\" %}{% endblock %}",
         "index", "{% extends \"skeleton\" %}{% block \"foo\" %}yada yada{% end %}{% block \"bar\" %}stuff{% endblock %}"
     );
-    String result = render(engine, "index", new TreeMap<String, Object>());
+    String result = render(engine, "index",new EmptyBindings());
     assertThat(result).isEqualTo("Helloyada yadaWorldstuff");
   }
 
@@ -46,7 +48,7 @@ public class ExtendsTagTest {
         "skeleton", "Hello{% block \"foo\" %}blah blah{% end %}World",
         "index", "{% extends \"skeleton\" %}"
     );
-    String result = render(engine, "index", new TreeMap<String, Object>());
+    String result = render(engine, "index", new EmptyBindings());
     assertThat(result).isEqualTo("Helloblah blahWorld");
   }
 
@@ -56,7 +58,7 @@ public class ExtendsTagTest {
         "index", "{% extends \"skeleton\" %}"
     );
     try {
-      engine.process("index", new TreeMap<String, Object>());
+      engine.process("index", new EmptyBindings());
       fail("Expected CarrotException.");
     } catch (CarrotException e) {
       assertThat(e.getMessage())
@@ -64,7 +66,7 @@ public class ExtendsTagTest {
     }
   }
 
-  private String render(CarrotEngine engine, String templateName, @Nullable Map<String, Object> bindings) {
+  private String render(CarrotEngine engine, String templateName, @Nullable Bindings bindings) {
     try {
       return engine.process(templateName, bindings);
     } catch (CarrotException e) {

--- a/src/test/java/au/com/codeka/carrot/tag/ForTagTest.java
+++ b/src/test/java/au/com/codeka/carrot/tag/ForTagTest.java
@@ -3,6 +3,7 @@ package au.com.codeka.carrot.tag;
 import au.com.codeka.carrot.CarrotEngine;
 import au.com.codeka.carrot.CarrotException;
 import au.com.codeka.carrot.Configuration;
+import au.com.codeka.carrot.bindings.MapBindings;
 import au.com.codeka.carrot.resource.MemoryResourceLocator;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -95,6 +96,6 @@ public class ForTagTest {
     MemoryResourceLocator resourceLocator = new MemoryResourceLocator(resources);
     engine.getConfig().setResourceLocater(resourceLocator);
 
-    return engine.process("index", bindings);
+    return engine.process("index", new MapBindings(bindings));
   }
 }

--- a/src/test/java/au/com/codeka/carrot/util/RenderHelper.java
+++ b/src/test/java/au/com/codeka/carrot/util/RenderHelper.java
@@ -3,6 +3,7 @@ package au.com.codeka.carrot.util;
 import au.com.codeka.carrot.CarrotEngine;
 import au.com.codeka.carrot.CarrotException;
 import au.com.codeka.carrot.Configuration;
+import au.com.codeka.carrot.bindings.MapBindings;
 import au.com.codeka.carrot.resource.MemoryResourceLocator;
 
 import java.util.HashMap;
@@ -37,6 +38,6 @@ public class RenderHelper {
       bindingsMap.put(bindings[i].toString(), bindings[i + 1]);
     }
 
-    return engine.process("index", bindingsMap);
+    return engine.process("index", new MapBindings(bindingsMap));
   }
 }


### PR DESCRIPTION
… compose the bindings from various sources without having to copy everything to a map. Implements #3

New bindings can adapt arbitrary sources, like Cursors, Android resources or Bundles, XML …

The following example show how the bindings can be composed from several sources:

```java
Bindings bindings = new Composite (
       new MapBindings(map1),
       new SingletonBindings("$json", new JsonObjectBindings(json)),
       new SingletonBindings("$map", new MapBindings(map2)),
   );
```

All the values in `map1` are accessible directly just like before

```
   {{ mapkey }}
```

The values in the JSON document and in `map2` are accessible with their prefixes

```
   {{ $json.key }}
   {{ $map.key }}
```

Also, in this commit:

In addition to the previous test, the following objects evaluate to true now:
* integers < 0
* non-empty CharSequences and Strings (the String check was broken before)
* non-empty Collections
* non-empty Maps and (nested) Bindings
* any other non-null and non-boolean value

Also, `for` blocks can now iterate arbitrary `Iterable`s.

Added a couple of test cases for the new code.