### PR TITLE
Extend `for` loop with support for expanding `Iterable`s.

### DIFF
--- a/src/main/java/au/com/codeka/carrot/bindings/EntryBindings.java
+++ b/src/main/java/au/com/codeka/carrot/bindings/EntryBindings.java
@@ -3,6 +3,8 @@ package au.com.codeka.carrot.bindings;
 import au.com.codeka.carrot.Bindings;
 
 import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -19,7 +21,7 @@ import java.util.Map;
  *
  * @author Marten Gajda
  */
-public final class EntryBindings implements Bindings {
+public final class EntryBindings implements Bindings, Iterable {
   private final Map.Entry<String, Object> entry;
 
   public EntryBindings(Map.Entry<String, Object> entry) {
@@ -41,5 +43,10 @@ public final class EntryBindings implements Bindings {
   @Override
   public boolean isEmpty() {
     return false;
+  }
+
+  @Override
+  public Iterator iterator() {
+    return Arrays.asList(entry.getKey(), entry.getValue()).iterator();
   }
 }

--- a/src/main/java/au/com/codeka/carrot/bindings/IterableExpansionBindings.java
+++ b/src/main/java/au/com/codeka/carrot/bindings/IterableExpansionBindings.java
@@ -1,0 +1,49 @@
+package au.com.codeka.carrot.bindings;
+
+import au.com.codeka.carrot.Bindings;
+import au.com.codeka.carrot.expr.Identifier;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Iterator;
+
+/**
+ * {@link Bindings} which expand an {@link Iterable} into multiple variables (given in an {@link Iterable} as well).
+ * <p>
+ * Each variable is assigned to the value at the same position in the values {@link Iterable}.
+ * <p>
+ * Note, this doesn't enforce any constraints. In particular the values {@link Iterable} can contain more values than the
+ * variables {@link Iterable} without any error. In this case the remaining values will remain unbound.
+ * If the variables contain more elements than the values, no error is thrown unless an "unbound" variable is accessed.
+ * <p>
+ * This behavior is different from Python where the variables must be equal to the number of values in the expanded iterable.
+ *
+ * @author Marten Gajda
+ */
+public final class IterableExpansionBindings implements Bindings {
+  private final Iterable<Identifier> identifiers;
+  private final Iterable<Object> values;
+
+  public IterableExpansionBindings(Iterable<Identifier> identifiers, Iterable<Object> values) {
+    this.identifiers = identifiers;
+    this.values = values;
+  }
+
+  @Nullable
+  @Override
+  public Object resolve(@Nonnull String key) {
+    Iterator<Object> values = this.values.iterator();
+    for (Identifier identifier : identifiers) {
+      Object nextValue = values.next();
+      if (key.equals(identifier.evaluate())) {
+        return nextValue;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return !values.iterator().hasNext();
+  }
+}

--- a/src/main/java/au/com/codeka/carrot/bindings/LoopVarBindings.java
+++ b/src/main/java/au/com/codeka/carrot/bindings/LoopVarBindings.java
@@ -1,0 +1,46 @@
+package au.com.codeka.carrot.bindings;
+
+import au.com.codeka.carrot.Bindings;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * {@link Bindings} of the loop variables of a for loop.
+ *
+ * @author Marten Gajda
+ */
+public final class LoopVarBindings implements Bindings {
+  private final int count;
+  private final int current;
+
+  public LoopVarBindings(int count, int current) {
+    this.count = count;
+    this.current = current;
+  }
+
+  @Nullable
+  @Override
+  public Object resolve(@Nonnull String key) {
+    switch (key) {
+      case "index":
+        return current;
+      case "revindex":
+        return count - current - 1;
+      case "first":
+        return current == 0;
+      case "last":
+        return current == (count - 1);
+      case "length":
+        return count;
+      default:
+        return null;
+    }
+  }
+
+  @Override
+  public boolean isEmpty() {
+    // loop bindings are never ever empty
+    return false;
+  }
+}

--- a/src/main/java/au/com/codeka/carrot/bindings/MapBindings.java
+++ b/src/main/java/au/com/codeka/carrot/bindings/MapBindings.java
@@ -3,6 +3,7 @@ package au.com.codeka.carrot.bindings;
 import au.com.codeka.carrot.Bindings;
 
 import javax.annotation.Nonnull;
+import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -10,7 +11,7 @@ import java.util.Map;
  *
  * @author Marten Gajda
  */
-public final class MapBindings implements Bindings {
+public final class MapBindings implements Bindings, Iterable {
   private final Map<String, Object> contextMap;
 
   public MapBindings(Map<String, Object> contextMap) {
@@ -25,5 +26,26 @@ public final class MapBindings implements Bindings {
   @Override
   public boolean isEmpty() {
     return contextMap.isEmpty();
+  }
+
+  @Override
+  public Iterator iterator() {
+    final Iterator<Map.Entry<String, Object>> iterator = contextMap.entrySet().iterator();
+    return new Iterator() {
+      @Override
+      public boolean hasNext() {
+        return iterator.hasNext();
+      }
+
+      @Override
+      public Object next() {
+        return new EntryBindings(iterator.next());
+      }
+
+      @Override
+      public void remove() {
+        throw new UnsupportedOperationException("This iterator does not support remove");
+      }
+    };
   }
 }

--- a/src/main/java/au/com/codeka/carrot/expr/StatementParser.java
+++ b/src/main/java/au/com/codeka/carrot/expr/StatementParser.java
@@ -5,6 +5,8 @@ import au.com.codeka.carrot.tag.Tag;
 import au.com.codeka.carrot.tmpl.TagNode;
 
 import javax.annotation.Nullable;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * StatementParser is used to parse expressions. Expressions are used to refer to everything that appears after the
@@ -74,6 +76,18 @@ public class StatementParser {
 
   public Identifier parseIdentifier() throws CarrotException {
     return new Identifier(tokenizer.expect(TokenType.IDENTIFIER));
+  }
+
+  public List<Identifier> parseIdentifierList() throws CarrotException {
+    List<Identifier> result = new LinkedList<>();
+    // first token of a list is always an identifier
+    result.add(new Identifier(tokenizer.expect(TokenType.IDENTIFIER)));
+    while (tokenizer.accept(TokenType.COMMA))
+    {
+      tokenizer.expect(TokenType.COMMA);
+      result.add(new Identifier(tokenizer.expect(TokenType.IDENTIFIER)));
+    }
+    return result;
   }
 
   public NumberLiteral parseNumber() throws CarrotException {

--- a/src/test/java/au/com/codeka/carrot/CarrotEngineTest.java
+++ b/src/test/java/au/com/codeka/carrot/CarrotEngineTest.java
@@ -1,15 +1,9 @@
 package au.com.codeka.carrot;
 
-import au.com.codeka.carrot.bindings.Composite;
-import au.com.codeka.carrot.bindings.EmptyBindings;
-import au.com.codeka.carrot.bindings.JsonArrayBindings;
-import au.com.codeka.carrot.bindings.JsonObjectBindings;
-import au.com.codeka.carrot.bindings.MapBindings;
-import au.com.codeka.carrot.bindings.SingletonBindings;
+import au.com.codeka.carrot.bindings.*;
 import au.com.codeka.carrot.resource.ResourceLocater;
 import au.com.codeka.carrot.resource.ResourceName;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Test;
@@ -19,7 +13,6 @@ import org.junit.runners.JUnit4;
 import javax.annotation.Nullable;
 import java.io.Reader;
 import java.io.StringReader;
-import java.util.HashMap;
 import java.util.Map;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -71,55 +64,70 @@ public class CarrotEngineTest {
   }
 
   @Test
-   public void testNestedBindings() {
-       assertThat(render("foo{{ $map.foo.bar[$map.baz] }}", new Composite(new SingletonBindings("$map", new MapBindings(ImmutableMap.of(
-               "foo", new Object() {
-                   public Map<String, String> getBar() {
-                       return ImmutableMap.of("hello", "World");
-                   }
-               },
-               "baz", "hello")))))).isEqualTo("fooWorld");
-   }
+  public void testNestedBindings() {
+    assertThat(render("foo{{ $map.foo.bar[$map.baz] }}", new Composite(new SingletonBindings("$map", new MapBindings(ImmutableMap.of(
+        "foo", new Object() {
+          public Map<String, String> getBar() {
+            return ImmutableMap.of("hello", "World");
+          }
+        },
+        "baz", "hello")))))).isEqualTo("fooWorld");
+  }
 
 
-    @Test
-    public void testJsonObjectIterable() {
-        //language=TEXT
-        assertThat(render("{% for item in $json %}{{ item.key }} -> {{ item.value }}\n{% end %}", new SingletonBindings("$json", new JsonObjectBindings(new JSONObject("{\n" +
-                "  \"key1\": \"a\",\n" +
-                "  \"key2\": 2,\n" +
-                "  \"key3\": true,\n" +
-                "  \"key4\": null\n" +
-                "}"))))).isEqualTo("key1 -> a\n" +
-                "key2 -> 2\n" +
-                "key3 -> true\n" +
-                "key4 -> \n");
-    }
+  @Test
+  public void testJsonObjectIterable() {
+    //language=TEXT
+    assertThat(render("{% for item in $json %}{{ item.key }} -> {{ item.value }}\n{% end %}", new SingletonBindings("$json", new JsonObjectBindings(new JSONObject("{\n" +
+        "  \"key1\": \"a\",\n" +
+        "  \"key2\": 2,\n" +
+        "  \"key3\": true,\n" +
+        "  \"key4\": null\n" +
+        "}"))))).isEqualTo("key1 -> a\n" +
+        "key2 -> 2\n" +
+        "key3 -> true\n" +
+        "key4 -> \n");
+  }
 
-    @Test
-    public void testNestedJsonObjectIterable() {
-        assertThat(render("{% for item in $json.map %}{{ item.key }} -> {{ $json.map[item.key] }}\n{% end %}", new SingletonBindings("$json", new JsonObjectBindings(new JSONObject("{\n" +
-                "  \"map\": {\n" +
-                "    \"key1\": \"a\",\n" +
-                "    \"key2\": 2,\n" +
-                "    \"key3\": true,\n" +
-                "    \"key4\": null\n" +
-                "  }\n" +
-                "}"))))).isEqualTo("key1 -> a\n" +
-                "key2 -> 2\n" +
-                "key3 -> true\n" +
-                "key4 -> \n");
-    }
 
-    @Test
-    public void testJsonArrayIterable() {
-        //language=TEXT
-        assertThat(render("{% for value in $json %}{{ value }}{% end %}",
-                new SingletonBindings("$json", new JsonArrayBindings(new JSONArray("[ \"a\", 2, true, null]")))))
-                .isEqualTo("a2true");
-    }
+  @Test
+  public void testJsonObjectIterableAlternativeNotation() {
+    //language=TEXT
+    assertThat(render("{% for key, value in $json %}{{ key }} -> {{ value }}\n{% end %}", new SingletonBindings("$json", new JsonObjectBindings(new JSONObject("{\n" +
+        "  \"key1\": \"a\",\n" +
+        "  \"key2\": 2,\n" +
+        "  \"key3\": true,\n" +
+        "  \"key4\": null\n" +
+        "}"))))).isEqualTo("key1 -> a\n" +
+        "key2 -> 2\n" +
+        "key3 -> true\n" +
+        "key4 -> \n");
+  }
 
-    private CarrotEngine createEngine() {
+  @Test
+  public void testNestedJsonObjectIterable() {
+    assertThat(render("{% for item in $json.map %}{{ item.key }} -> {{ $json.map[item.key] }}\n{% end %}", new SingletonBindings("$json", new JsonObjectBindings(new JSONObject("{\n" +
+        "  \"map\": {\n" +
+        "    \"key1\": \"a\",\n" +
+        "    \"key2\": 2,\n" +
+        "    \"key3\": true,\n" +
+        "    \"key4\": null\n" +
+        "  }\n" +
+        "}"))))).isEqualTo("key1 -> a\n" +
+        "key2 -> 2\n" +
+        "key3 -> true\n" +
+        "key4 -> \n");
+  }
+
+  @Test
+  public void testJsonArrayIterable() {
+    //language=TEXT
+    assertThat(render("{% for value in $json %}{{ value }}{% end %}",
+        new SingletonBindings("$json", new JsonArrayBindings(new JSONArray("[ \"a\", 2, true, null]")))))
+        .isEqualTo("a2true");
+  }
+
+  private CarrotEngine createEngine() {
     CarrotEngine engine = new CarrotEngine();
     engine.getConfig().setLogger(new Configuration.Logger() {
       @Override
@@ -143,7 +151,9 @@ public class CarrotEngineTest {
     }
   }
 
-  /** A test {@link ResourceLocater} that simple returns a static string content. */
+  /**
+   * A test {@link ResourceLocater} that simple returns a static string content.
+   */
   private class TestResourceLocator implements ResourceLocater {
     private String content;
 

--- a/src/test/java/au/com/codeka/carrot/tag/ForTagTest.java
+++ b/src/test/java/au/com/codeka/carrot/tag/ForTagTest.java
@@ -10,10 +10,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -25,10 +22,11 @@ public class ForTagTest {
   @Test
   public void testArrayLoop() throws CarrotException {
     Map<String, Object> context = new HashMap<>();
-    context.put("values", new int[] { 3, 1, 4, 1, 5 });
+    context.put("values", new int[]{3, 1, 4, 1, 5});
     assertThat(render("foo{% for n in values %}a {{ n }} b{% end %}bar", context))
         .isEqualTo("fooa 3 ba 1 ba 4 ba 1 ba 5 bbar");
   }
+
 
   @Test
   public void testArrayListLoop() throws CarrotException {
@@ -42,6 +40,44 @@ public class ForTagTest {
         .isEqualTo("Hello  -foo-  -bar-  -baz-  World");
   }
 
+
+  @Test
+  public void testArrayExpansionLoop() throws CarrotException {
+    Map<String, Object> context = new HashMap<>();
+    ArrayList<List<String>> values = new ArrayList<>();
+    values.add(Arrays.asList("foo", "bar", "baz"));
+    values.add(Arrays.asList("1", "2", "3"));
+    values.add(Arrays.asList("a", "b", "c"));
+    context.put("values", values);
+    assertThat(render("Hello {% for x, y, z in values %} -{{ x }}/{{ y }}/{{ z }}- {% end %} World", context))
+        .isEqualTo("Hello  -foo/bar/baz-  -1/2/3-  -a/b/c-  World");
+  }
+
+
+  @Test
+  public void testMapExpansionLoop() throws CarrotException {
+    Map<String, Object> context = new HashMap<>();
+    Map<String, Object> values = new HashMap<>();
+    // note, we can not test Map iteration with more values, because the iteration order is undefined
+    values.put("foo", "a");
+    context.put("values", new MapBindings(values));
+    assertThat(render("Hello {% for key, val in values %} -{{ key }}:{{ val }}- {% end %} World", context))
+        .isEqualTo("Hello  -foo:a-  World");
+  }
+
+
+  @Test
+  public void testVariableExpansionLoop2() throws CarrotException {
+    Map<String, Object> context = new HashMap<>();
+    ArrayList<List<String>> values = new ArrayList<>();
+    values.add(Arrays.asList("foo", "bar", "baz"));
+    values.add(Arrays.asList("1", "2", "3"));
+    values.add(Arrays.asList("a", "b", "c"));
+    context.put("values", values);
+    assertThat(render("Hello {% for x,y, z in values %} -{{ x }}/{{ y }}/{{ z }}- {% end %} World", context))
+        .isEqualTo("Hello  -foo/bar/baz-  -1/2/3-  -a/b/c-  World");
+  }
+
   @Test
   public void testLoopVariables() throws CarrotException {
     Map<String, Object> context = new HashMap<>();
@@ -53,8 +89,9 @@ public class ForTagTest {
     assertThat(render("{% for str in values %}"
         + "{{ str }} {{ loop.index }} {{ loop.revindex }} {{ loop.first }} {{ loop.last }} {{ loop.length }}"
         + "{% end %}", context))
-            .isEqualTo("foo 0 2 true false 3bar 1 1 false false 3baz 2 0 false true 3");
+        .isEqualTo("foo 0 2 true false 3bar 1 1 false false 3baz 2 0 false true 3");
   }
+
 
   @Test
   public void testEmptyCollectionWithNoElse() throws CarrotException {
@@ -82,11 +119,9 @@ public class ForTagTest {
 
   private String render(String content, @Nullable Map<String, Object> bindings) throws CarrotException {
     CarrotEngine engine = new CarrotEngine();
-    engine.getConfig().setLogger(new Configuration.Logger()
-    {
+    engine.getConfig().setLogger(new Configuration.Logger() {
       @Override
-      public void print(int level, String msg)
-      {
+      public void print(int level, String msg) {
         System.err.println(msg);
       }
     });


### PR DESCRIPTION
For example, if you have bound the following json array to `jsonArray`:

```
[
  ["a", "b", "c"],
  ["d", "e", "f"],
  ["g", "h", "i"]
]
```

The following template

```
{% for x, y, z in jsonArray %}{{ z }}/{{ y }}/{{ x }}
{% end %}
```

renders to:

```
c/b/a
f/e/d
i/h/g
```

This commit also extends `MapBindings` and `EntryBindings` to be `Iterable` which allows you to do this:

```
{% for key, value in $json %}
{{ key }} -> {{ value }}
{% end %}
```

Note that expansion is rather tolerant and it's not required that the number of variables and values match.
The only error condition is when you actually access an "unbound" variable (i.e. a variable which has no corresponding value).

If only one loop identifier is given, the current behavior doesn't change.