### PR TITLE
Make EmptyBindings and SingletonBindings iterable to allow using them…

### DIFF
--- a/src/main/java/au/com/codeka/carrot/bindings/EmptyBindings.java
+++ b/src/main/java/au/com/codeka/carrot/bindings/EmptyBindings.java
@@ -3,13 +3,15 @@ package au.com.codeka.carrot.bindings;
 import au.com.codeka.carrot.Bindings;
 
 import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.Iterator;
 
 /**
  * {@link Bindings} without any values.
  *
  * @author Marten Gajda
  */
-public final class EmptyBindings implements Bindings {
+public final class EmptyBindings implements Bindings, Iterable<EntryBindings> {
   @Override
   public Object resolve(@Nonnull String key) {
     return null;
@@ -18,5 +20,10 @@ public final class EmptyBindings implements Bindings {
   @Override
   public boolean isEmpty() {
     return true;
+  }
+
+  @Override
+  public Iterator<EntryBindings> iterator() {
+    return Collections.<EntryBindings>emptyList().iterator();
   }
 }

--- a/src/main/java/au/com/codeka/carrot/bindings/EntryBindings.java
+++ b/src/main/java/au/com/codeka/carrot/bindings/EntryBindings.java
@@ -3,6 +3,7 @@ package au.com.codeka.carrot.bindings;
 import au.com.codeka.carrot.Bindings;
 
 import javax.annotation.Nonnull;
+import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
@@ -21,8 +22,13 @@ import java.util.Map;
  *
  * @author Marten Gajda
  */
-public final class EntryBindings implements Bindings, Iterable {
+public final class EntryBindings implements Bindings, Iterable<Object> {
   private final Map.Entry<String, Object> entry;
+
+
+  public EntryBindings(String key, Object value) {
+    this(new AbstractMap.SimpleImmutableEntry<>(key, value));
+  }
 
   public EntryBindings(Map.Entry<String, Object> entry) {
     this.entry = entry;
@@ -46,7 +52,7 @@ public final class EntryBindings implements Bindings, Iterable {
   }
 
   @Override
-  public Iterator iterator() {
+  public Iterator<Object> iterator() {
     return Arrays.asList(entry.getKey(), entry.getValue()).iterator();
   }
 }

--- a/src/main/java/au/com/codeka/carrot/bindings/JsonArrayBindings.java
+++ b/src/main/java/au/com/codeka/carrot/bindings/JsonArrayBindings.java
@@ -14,7 +14,7 @@ import java.util.NoSuchElementException;
  *
  * @author Marten Gajda
  */
-public final class JsonArrayBindings implements Bindings, Iterable {
+public final class JsonArrayBindings implements Bindings, Iterable<Object> {
   private final JSONArray jsonArray;
 
   public JsonArrayBindings(JSONArray jsonArray) {
@@ -32,8 +32,8 @@ public final class JsonArrayBindings implements Bindings, Iterable {
   }
 
   @Override
-  public Iterator iterator() {
-    return new Iterator() {
+  public Iterator<Object> iterator() {
+    return new Iterator<Object>() {
       int index = 0;
 
       @Override

--- a/src/main/java/au/com/codeka/carrot/bindings/JsonObjectBindings.java
+++ b/src/main/java/au/com/codeka/carrot/bindings/JsonObjectBindings.java
@@ -5,7 +5,6 @@ import au.com.codeka.carrot.ValueHelper;
 import org.json.JSONObject;
 
 import javax.annotation.Nonnull;
-import java.util.AbstractMap;
 import java.util.Iterator;
 
 /**
@@ -13,7 +12,7 @@ import java.util.Iterator;
  *
  * @author Marten Gajda
  */
-public final class JsonObjectBindings implements Bindings, Iterable {
+public final class JsonObjectBindings implements Bindings, Iterable<EntryBindings> {
   private final JSONObject jsonObject;
 
   public JsonObjectBindings(JSONObject jsonObject) {
@@ -31,14 +30,14 @@ public final class JsonObjectBindings implements Bindings, Iterable {
   }
 
   @Override
-  public Iterator iterator() {
+  public Iterator<EntryBindings> iterator() {
     final Iterator<String> keys = jsonObject.keys();
 
     // return an iterator of Map Entries which allows iterating json objects like this:
     // {% for item in json %}
     //    {{ item.key }} -> {{ item.value }}
     // {% end %}
-    return new Iterator() {
+    return new Iterator<EntryBindings>() {
       @Override
       public boolean hasNext() {
         return keys.hasNext();
@@ -50,9 +49,9 @@ public final class JsonObjectBindings implements Bindings, Iterable {
       }
 
       @Override
-      public Object next() {
+      public EntryBindings next() {
         final String key = keys.next();
-        return new EntryBindings(new AbstractMap.SimpleImmutableEntry<>(key, ValueHelper.jsonHelper(jsonObject.opt(key))));
+        return new EntryBindings(key, ValueHelper.jsonHelper(jsonObject.opt(key)));
       }
     };
   }

--- a/src/main/java/au/com/codeka/carrot/bindings/MapBindings.java
+++ b/src/main/java/au/com/codeka/carrot/bindings/MapBindings.java
@@ -11,7 +11,7 @@ import java.util.Map;
  *
  * @author Marten Gajda
  */
-public final class MapBindings implements Bindings, Iterable {
+public final class MapBindings implements Bindings, Iterable<EntryBindings> {
   private final Map<String, Object> contextMap;
 
   public MapBindings(Map<String, Object> contextMap) {
@@ -29,16 +29,16 @@ public final class MapBindings implements Bindings, Iterable {
   }
 
   @Override
-  public Iterator iterator() {
+  public Iterator<EntryBindings> iterator() {
     final Iterator<Map.Entry<String, Object>> iterator = contextMap.entrySet().iterator();
-    return new Iterator() {
+    return new Iterator<EntryBindings>() {
       @Override
       public boolean hasNext() {
         return iterator.hasNext();
       }
 
       @Override
-      public Object next() {
+      public EntryBindings next() {
         return new EntryBindings(iterator.next());
       }
 

--- a/src/main/java/au/com/codeka/carrot/bindings/SingletonBindings.java
+++ b/src/main/java/au/com/codeka/carrot/bindings/SingletonBindings.java
@@ -3,13 +3,15 @@ package au.com.codeka.carrot.bindings;
 import au.com.codeka.carrot.Bindings;
 
 import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.Iterator;
 
 /**
  * {@link Bindings} with exactly one value.
  *
  * @author Marten Gajda
  */
-public final class SingletonBindings implements Bindings {
+public final class SingletonBindings implements Bindings, Iterable<EntryBindings> {
   private final String key;
   private final Object value;
 
@@ -26,5 +28,10 @@ public final class SingletonBindings implements Bindings {
   @Override
   public boolean isEmpty() {
     return false;
+  }
+
+  @Override
+  public Iterator<EntryBindings> iterator() {
+    return Collections.singleton(new EntryBindings(key, value)).iterator();
   }
 }

--- a/src/test/java/au/com/codeka/carrot/bindings/CompositeTest.java
+++ b/src/test/java/au/com/codeka/carrot/bindings/CompositeTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertThat;
  * @author marten
  */
 public class CompositeTest {
+
   @Test
   public void testResolved() throws Exception {
     assertThat(new Composite().resolve("key"), CoreMatchers.nullValue());

--- a/src/test/java/au/com/codeka/carrot/bindings/EmptyBindingsTest.java
+++ b/src/test/java/au/com/codeka/carrot/bindings/EmptyBindingsTest.java
@@ -10,6 +10,11 @@ import static org.junit.Assert.assertThat;
  */
 public class EmptyBindingsTest {
   @Test
+  public void testIterator() throws Exception {
+    assertThat(new EmptyBindings().iterator().hasNext(), CoreMatchers.is(false));
+  }
+
+  @Test
   public void testResolved() throws Exception {
     assertThat(new EmptyBindings().resolve("abc"), CoreMatchers.nullValue());
   }

--- a/src/test/java/au/com/codeka/carrot/bindings/LoopVarBindingsTest.java
+++ b/src/test/java/au/com/codeka/carrot/bindings/LoopVarBindingsTest.java
@@ -1,0 +1,40 @@
+package au.com.codeka.carrot.bindings;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author marten
+ */
+public class LoopVarBindingsTest {
+  @Test
+  public void testResolve() throws Exception {
+    assertThat(new LoopVarBindings(3, 1).resolve("index"), CoreMatchers.<Object>is(1));
+    assertThat(new LoopVarBindings(3, 1).resolve("revindex"), CoreMatchers.<Object>is(1));
+    assertThat(new LoopVarBindings(3, 1).resolve("first"), CoreMatchers.<Object>is(false));
+    assertThat(new LoopVarBindings(3, 1).resolve("last"), CoreMatchers.<Object>is(false));
+    assertThat(new LoopVarBindings(3, 1).resolve("length"), CoreMatchers.<Object>is(3));
+
+
+    assertThat(new LoopVarBindings(3, 0).resolve("index"), CoreMatchers.<Object>is(0));
+    assertThat(new LoopVarBindings(3, 0).resolve("revindex"), CoreMatchers.<Object>is(2));
+    assertThat(new LoopVarBindings(3, 0).resolve("first"), CoreMatchers.<Object>is(true));
+    assertThat(new LoopVarBindings(3, 0).resolve("last"), CoreMatchers.<Object>is(false));
+    assertThat(new LoopVarBindings(3, 0).resolve("length"), CoreMatchers.<Object>is(3));
+
+    assertThat(new LoopVarBindings(3, 2).resolve("index"), CoreMatchers.<Object>is(2));
+    assertThat(new LoopVarBindings(3, 2).resolve("revindex"), CoreMatchers.<Object>is(0));
+    assertThat(new LoopVarBindings(3, 2).resolve("first"), CoreMatchers.<Object>is(false));
+    assertThat(new LoopVarBindings(3, 2).resolve("last"), CoreMatchers.<Object>is(true));
+    assertThat(new LoopVarBindings(3, 2).resolve("length"), CoreMatchers.<Object>is(3));
+  }
+
+  @Test
+  public void testIsEmpty() throws Exception {
+    assertThat(new LoopVarBindings(1, 0).isEmpty(), CoreMatchers.is(false));
+    assertThat(new LoopVarBindings(3, 1).isEmpty(), CoreMatchers.is(false));
+  }
+
+}

--- a/src/test/java/au/com/codeka/carrot/bindings/SingletonBindingsTest.java
+++ b/src/test/java/au/com/codeka/carrot/bindings/SingletonBindingsTest.java
@@ -10,6 +10,12 @@ import static org.junit.Assert.assertThat;
  */
 public class SingletonBindingsTest {
   @Test
+  public void testIterator() throws Exception {
+    assertThat(new SingletonBindings("key", "value").iterator().hasNext(), CoreMatchers.is(true));
+    assertThat(new SingletonBindings("key", "value").iterator().next(), CoreMatchers.instanceOf(EntryBindings.class));
+  }
+
+  @Test
   public void testResolved() throws Exception {
     assertThat(new SingletonBindings("key", "value").resolve("key"), CoreMatchers.<Object>is("value"));
     assertThat(new SingletonBindings("key", "value").resolve("otherkey"), CoreMatchers.nullValue());


### PR DESCRIPTION
… in place of other Iterable Bindings when no or just a single value need to be returned.

As it turned out this is quite useful.