### PR TITLE
Make ResourceName an interface and create AbstractResourceName as a d…

### DIFF
--- a/src/main/java/au/com/codeka/carrot/resource/AbstractResourceName.java
+++ b/src/main/java/au/com/codeka/carrot/resource/AbstractResourceName.java
@@ -1,0 +1,27 @@
+package au.com.codeka.carrot.resource;
+
+import javax.annotation.Nullable;
+
+/**
+ * Abstract implementation of a {@link ResourceName}.
+ */
+public abstract class AbstractResourceName implements ResourceName {
+  protected final String name;
+  @Nullable
+  protected final ResourceName parent;
+
+  public AbstractResourceName(@Nullable ResourceName parent, String name) {
+    this.parent = parent;
+    this.name = name;
+  }
+
+  /**
+   * @return The name of this resource, which may be relative to the parent (i.e. not necessarily a direct child of the
+   * parent). Relative names are always separated with forward slash '/'.
+   */
+  @Override
+  public String getName() {
+    return name;
+  }
+
+}

--- a/src/main/java/au/com/codeka/carrot/resource/FileResourceLocater.java
+++ b/src/main/java/au/com/codeka/carrot/resource/FileResourceLocater.java
@@ -68,7 +68,7 @@ public class FileResourceLocater implements ResourceLocater {
   }
 
   /** Our version of {@link ResourceName} that represents file system files. */
-  private static class FileResourceName extends ResourceName {
+  private static class FileResourceName extends AbstractResourceName {
     private final File file;
 
     public FileResourceName(@Nullable ResourceName parent, String name, File file) {

--- a/src/main/java/au/com/codeka/carrot/resource/MemoryResourceLocator.java
+++ b/src/main/java/au/com/codeka/carrot/resource/MemoryResourceLocator.java
@@ -56,7 +56,7 @@ public class MemoryResourceLocator implements ResourceLocater {
   }
 
   /** Our version of {@link ResourceName} that represents file system files. */
-  private static class MemoryResourceName extends ResourceName {
+  private static class MemoryResourceName extends AbstractResourceName {
     private final String name;
 
     public MemoryResourceName(@Nullable ResourceName parent, String name) {

--- a/src/main/java/au/com/codeka/carrot/resource/ResourceName.java
+++ b/src/main/java/au/com/codeka/carrot/resource/ResourceName.java
@@ -5,29 +5,21 @@ import javax.annotation.Nullable;
 /**
  * The "name" of a resolved resource (usually a file, but not nessecarily). You can pass this to a resource locator
  * to get the actual contents of the resource.
- *
+ * <p>
  * <p>{@link ResourceName}s may be related to a parent {@link ResourceName}. They may not necessarily be direct
  * children of the parent, in which case children will always be separated by a forward slash '/'.
  */
-public abstract class ResourceName {
-  protected final String name;
-  @Nullable protected final ResourceName parent;
-
-  public ResourceName(@Nullable ResourceName parent, String name) {
-    this.parent = parent;
-    this.name = name;
-  }
+public interface ResourceName {
 
   /**
    * @return The name of this resource, which may be relative to the parent (i.e. not necessarily a direct child of the
-   *         parent). Relative names are always separated with forward slash '/'.
+   * parent). Relative names are always separated with forward slash '/'.
    */
-  public String getName() {
-    return name;
-  }
+  String getName();
 
   /**
    * @return The parent {@link ResourceName} (may be null if this {@link ResourceName} is relative to the root).
    */
-  @Nullable public abstract ResourceName getParent();
+  @Nullable
+  ResourceName getParent();
 }

--- a/src/test/java/au/com/codeka/carrot/CarrotEngineTest.java
+++ b/src/test/java/au/com/codeka/carrot/CarrotEngineTest.java
@@ -1,6 +1,7 @@
 package au.com.codeka.carrot;
 
 import au.com.codeka.carrot.bindings.*;
+import au.com.codeka.carrot.resource.AbstractResourceName;
 import au.com.codeka.carrot.resource.ResourceLocater;
 import au.com.codeka.carrot.resource.ResourceName;
 import com.google.common.collect.ImmutableMap;
@@ -163,7 +164,7 @@ public class CarrotEngineTest {
 
     @Override
     public ResourceName findResource(@Nullable ResourceName parent, String name) throws CarrotException {
-      return new ResourceName(parent, name) {
+      return new AbstractResourceName(parent, name) {
         @Nullable
         @Override
         public ResourceName getParent() {


### PR DESCRIPTION
…rop-in replacement.

Having ResourceName being an interface makes it easier to create classes for resources which are not file system based. For instance, on Android you might refer to a "raw resource" which is identified by an integer in Java code.