### PR TITLE
Extend `SetTag` with support for non-block assignments.

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -2,6 +2,9 @@
 <project version="4">
   <component name="CompilerConfiguration">
     <bytecodeTargetLevel>
+      <module name="carrot_docs" target="1.7" />
+      <module name="carrot_main" target="1.7" />
+      <module name="carrot_test" target="1.7" />
       <module name="git_docs" target="1.7" />
       <module name="git_main" target="1.7" />
       <module name="git_test" target="1.7" />

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,6 +2,10 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/carrot.iml" filepath="$PROJECT_DIR$/.idea/modules/carrot.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/carrot_docs.iml" filepath="$PROJECT_DIR$/.idea/modules/carrot_docs.iml" group="carrot" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/carrot_main.iml" filepath="$PROJECT_DIR$/.idea/modules/carrot_main.iml" group="carrot" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/carrot_test.iml" filepath="$PROJECT_DIR$/.idea/modules/carrot_test.iml" group="carrot" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/git.iml" filepath="$PROJECT_DIR$/.idea/modules/git.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/git_docs.iml" filepath="$PROJECT_DIR$/.idea/modules/git_docs.iml" group="git" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/git_main.iml" filepath="$PROJECT_DIR$/.idea/modules/git_main.iml" group="git" />

--- a/src/main/java/au/com/codeka/carrot/expr/StatementParser.java
+++ b/src/main/java/au/com/codeka/carrot/expr/StatementParser.java
@@ -11,7 +11,7 @@ import java.util.List;
 /**
  * StatementParser is used to parse expressions. Expressions are used to refer to everything that appears after the
  * {@link Tag} in a {@link TagNode}, and has the following pseudo-EBNF grammar:
- *
+ * <p>
  * <pre><code>
  *   expression = ["!"] notcond
  *
@@ -40,7 +40,7 @@ import java.util.List;
  *   number = "and valid Java number"
  *   literal = """ anything """
  * </code></pre>
- *
+ * <p>
  * <p>The statement parser allows you to extract any sub-element from a string as well (for example, the ForTag
  * wants to pull off it's arguments an identifier followed by the identifier "in" followed by a statement.
  */
@@ -82,8 +82,7 @@ public class StatementParser {
     List<Identifier> result = new LinkedList<>();
     // first token of a list is always an identifier
     result.add(new Identifier(tokenizer.expect(TokenType.IDENTIFIER)));
-    while (tokenizer.accept(TokenType.COMMA))
-    {
+    while (tokenizer.accept(TokenType.COMMA)) {
       tokenizer.expect(TokenType.COMMA);
       result.add(new Identifier(tokenizer.expect(TokenType.IDENTIFIER)));
     }
@@ -96,6 +95,15 @@ public class StatementParser {
 
   public StringLiteral parseString() throws CarrotException {
     return new StringLiteral(tokenizer.expect(TokenType.STRING_LITERAL));
+  }
+
+  public boolean isAssignment() throws CarrotException {
+    if (!tokenizer.accept(TokenType.ASSIGNMENT)) {
+      return false;
+    }
+    // consume the assignment operator
+    tokenizer.expect(TokenType.ASSIGNMENT);
+    return true;
   }
 
   public Expression parseExpression() throws CarrotException {
@@ -127,7 +135,7 @@ public class StatementParser {
 
   OrCond parseOrCond() throws CarrotException {
     Comparator lhs = parseComparator();
-    TokenType[] validTypes = new TokenType[] {
+    TokenType[] validTypes = new TokenType[]{
         TokenType.EQUALITY,
         TokenType.INEQUALITY,
         TokenType.LESS_THAN,

--- a/src/main/java/au/com/codeka/carrot/expr/TokenType.java
+++ b/src/main/java/au/com/codeka/carrot/expr/TokenType.java
@@ -28,6 +28,9 @@ public enum TokenType {
   /** Right-square-bracket: ] */
   RSQUARE(false),
 
+  /** Single Equals: = */
+  ASSIGNMENT(false),
+
   COMMA(false),
   DOT(false),
   NOT(false),

--- a/src/main/java/au/com/codeka/carrot/expr/Tokenizer.java
+++ b/src/main/java/au/com/codeka/carrot/expr/Tokenizer.java
@@ -1,21 +1,20 @@
 package au.com.codeka.carrot.expr;
 
 import au.com.codeka.carrot.CarrotException;
-import au.com.codeka.carrot.resource.ResourcePointer;
 import au.com.codeka.carrot.util.LineReader;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.ArrayDeque;
-import java.util.Queue;
 
 /**
  * Converts an input {@link Reader} into a stream of {@link Token}s.
  */
 public class Tokenizer {
   private final LineReader reader;
-  @Nullable private Character lookahead;
+  @Nullable
+  private Character lookahead;
   private ArrayDeque<Token> tokens = new ArrayDeque<>();
 
   public Tokenizer(LineReader reader) throws CarrotException {
@@ -46,7 +45,7 @@ public class Tokenizer {
    * is the current one, the 1st is the after that and so on. This can be used to "look ahead" into the token stream.
    *
    * @param offset The offset from "current" that we want to peek. 0 is the current token, 1 is the next and so on.
-   * @param type The {@link TokenType} we want to accept.
+   * @param type   The {@link TokenType} we want to accept.
    * @return True, if the current token is of the given type, or false it's not.
    * @throws CarrotException If there's an error parsing the tokens.
    */
@@ -177,9 +176,13 @@ public class Tokenizer {
       case '=':
         next = nextChar();
         if (next != '=') {
-          throw new CarrotException("Expected ==", reader.getPointer());
+          if (next > 0) {
+            lookahead = (char) next;
+          }
+          token = new Token(TokenType.ASSIGNMENT);
+        } else {
+          token = new Token(TokenType.EQUALITY);
         }
-        token = new Token(TokenType.EQUALITY);
         break;
       case '!':
         next = nextChar();

--- a/src/test/java/au/com/codeka/carrot/expr/TokenizerTest.java
+++ b/src/test/java/au/com/codeka/carrot/expr/TokenizerTest.java
@@ -84,14 +84,10 @@ public class TokenizerTest {
     assertThat(tokenizer.expect(TokenType.NOT)).isNotNull();
     assertThat(tokenizer.expect(TokenType.IDENTIFIER).getValue()).isEqualTo("b");
 
-    try {
-      tokenizer = createTokenizer("a = b");
-      assertThat(tokenizer.expect(TokenType.IDENTIFIER).getValue()).isEqualTo("a");
-      assertThat(tokenizer.expect(TokenType.EQUALITY)).isNotNull();
-      fail("Expected CarrotException");
-    } catch (CarrotException e) {
-      assertThat(e.getMessage()).isEqualTo("???\n1: a = b\n       ^\nExpected ==");
-    }
+    tokenizer = createTokenizer("a = b");
+    assertThat(tokenizer.expect(TokenType.IDENTIFIER).getValue()).isEqualTo("a");
+    assertThat(tokenizer.expect(TokenType.ASSIGNMENT)).isNotNull();
+    assertThat(tokenizer.expect(TokenType.IDENTIFIER).getValue()).isEqualTo("b");
   }
 
   @Test
@@ -150,7 +146,7 @@ public class TokenizerTest {
       assertThat(tokenizer.expect(TokenType.PLUS).getType()).isEqualTo(TokenType.PLUS);
       assertThat(tokenizer.expect(TokenType.IDENTIFIER).getValue()).isEqualTo("b");
       fail("Expected CarrotException");
-    } catch(CarrotException e) {
+    } catch (CarrotException e) {
       assertThat(e.getMessage()).isEqualTo("???\n1: a + + b\n        ^\nExpected token of type IDENTIFIER, got PLUS");
     }
 
@@ -160,7 +156,7 @@ public class TokenizerTest {
       assertThat(tokenizer.expect(TokenType.PLUS).getType()).isEqualTo(TokenType.PLUS);
       assertThat(tokenizer.expect(TokenType.IDENTIFIER, TokenType.NUMBER_LITERAL, TokenType.STRING_LITERAL).getValue()).isEqualTo("b");
       fail("Expected CarrotException");
-    } catch(CarrotException e) {
+    } catch (CarrotException e) {
       assertThat(e.getMessage()).isEqualTo("???\n1: a + + b\n        ^\nExpected token of type IDENTIFIER, NUMBER_LITERAL or STRING_LITERAL, got PLUS");
     }
   }

--- a/src/test/java/au/com/codeka/carrot/tag/SetTagHelper.java
+++ b/src/test/java/au/com/codeka/carrot/tag/SetTagHelper.java
@@ -5,6 +5,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.util.Arrays;
+
 import static au.com.codeka.carrot.util.RenderHelper.render;
 import static com.google.common.truth.Truth.assertThat;
 
@@ -24,4 +26,17 @@ public class SetTagHelper {
     assertThat(render("{% set foo %}Hello <b>World</b>{% end %}foo={{ html.safe(foo) }}"))
         .isEqualTo("foo=Hello <b>World</b>");
   }
+
+  @Test
+  public void testExpression() throws CarrotException {
+    assertThat(render("{% set foo = 'bar' %}foo={{ foo }}"))
+        .isEqualTo("foo=bar");
+  }
+
+  @Test
+  public void testExpansion() throws CarrotException {
+    assertThat(render("{% set foo, bar = baz %}foo={{ foo }}, bar={{ bar }}", "baz", Arrays.asList("bing", "bong")))
+        .isEqualTo("foo=bing, bar=bong");
+  }
+
 }


### PR DESCRIPTION
Examples

Assign a single value:

```
  {% set foo = "bar" %}
```

Unpack multiple values (which requires the expression to the right to evaluate to an `Iterable`).

```
  {% set foo, bar = foobar %}
```

Note, if the right side evaluates to an `Iterable` but there is only one variable to the left, the whole `Iterable` will be assigned to the variable, not only the first value of it.