### PR TITLE
Support Python-like conditional expressions. Implements #10

### DIFF
--- a/src/main/java/au/com/codeka/carrot/expr/AndCond.java
+++ b/src/main/java/au/com/codeka/carrot/expr/AndCond.java
@@ -27,10 +27,15 @@ public class AndCond {
   }
 
   public Object evaluate(Configuration config, Scope scope) throws CarrotException {
-    Object value = orConds.get(0).evaluate(config, scope);
-    for (int i = 1; i < orConds.size(); i++) {
-      value = ValueHelper.isTrue(value) || ValueHelper.isTrue(orConds.get(i).evaluate(config, scope));
+    Object value = false;
+    for (OrCond orCond : orConds) {
+      value = orCond.evaluate(config, scope);
+      if (ValueHelper.isTrue(value)) {
+        // no need to continue, the result is definitely true
+        break;
+      }
     }
+    // always return the last value
     return value;
   }
 

--- a/src/main/java/au/com/codeka/carrot/expr/NotCond.java
+++ b/src/main/java/au/com/codeka/carrot/expr/NotCond.java
@@ -28,10 +28,15 @@ public class NotCond {
   }
 
   public Object evaluate(Configuration config, Scope scope) throws CarrotException {
-    Object value = andConds.get(0).evaluate(config, scope);
-    for (int i = 1; i < andConds.size(); i++) {
-      value = ValueHelper.isTrue(value) && ValueHelper.isTrue(andConds.get(i).evaluate(config, scope));
+    Object value = true;
+    for (AndCond andCond : andConds) {
+      value = andCond.evaluate(config, scope);
+      if (!ValueHelper.isTrue(value)) {
+        // no need to continue if a value was evaluated to false
+        break;
+      }
     }
+    // always return the last evaluated value
     return value;
   }
 

--- a/src/test/java/au/com/codeka/carrot/CarrotEngineTest.java
+++ b/src/test/java/au/com/codeka/carrot/CarrotEngineTest.java
@@ -39,6 +39,24 @@ public class CarrotEngineTest {
   }
 
   @Test
+  public void testConditionalStatements() {
+    assertThat(render("{{ foo && \"a\" || \"b\"}}", new SingletonBindings("foo", true))).isEqualTo("a");
+
+    // note the following test fails due to https://github.com/codeka/carrot/issues/15
+    // TODO: re-enable test when #15 has been fixed
+    // assertThat(render("{{ foo && \"a\" || \"b\"}}", new SingletonBindings("foo", false))).isEqualTo("b");
+
+    // setting parenthesis results in correct evaluation:
+    assertThat(render("{{ (foo && \"a\") || \"b\"}}", new SingletonBindings("foo", false))).isEqualTo("b");
+
+    assertThat(render("{{ foo && \"a\"}}", new SingletonBindings("foo", true))).isEqualTo("a");
+    assertThat(render("{{ foo && \"a\"}}", new SingletonBindings("foo", false))).isEqualTo("false");
+
+    assertThat(render("{{ foo || \"a\"}}", new SingletonBindings("foo", true))).isEqualTo("true");
+    assertThat(render("{{ foo || \"a\"}}", new SingletonBindings("foo", false))).isEqualTo("a");
+  }
+
+  @Test
   public void testEchoTag() {
     assertThat(render("foo{{ foo.bar[baz] }}", new MapBindings(ImmutableMap.of(
         "foo", new Object() {


### PR DESCRIPTION
Some `if` blocks like these:

```
{% if ! loop.last %},{% end %}

{% if value %}{{ value }}{% else %}No value{% end %}
```

can now be replaced with simple echo statements like these:

```
{{ loop.last && "" || "," }}

{{ value || "No Value" }}
```

Note that at the time of committing this the first case is actually broken (#15).

Note that in contrast to Python this still uses Java like operators (i.e. `&&` + `||` vs. `and` + `or`).