### PR TITLE
Fix grammar and parsing of unary and binary terms.

### DIFF
--- a/src/main/java/au/com/codeka/carrot/expr/StatementParser.java
+++ b/src/main/java/au/com/codeka/carrot/expr/StatementParser.java
@@ -22,19 +22,19 @@ import java.util.List;
  *     | literal
  *     | "(" expression ")"
  *
- *   unary-term = ["!"] value
+ *   unary-term = ["!"] unary-term
  *
- *   multiplicative-term = unnary-term [("*" | "/") unary-term]
+ *   multiplicative-term = unnary-term [("*" | "/") multiplicative-term]
  *
- *   additive-term = multiplicative-term [("+" | "-") multiplicative-term]
+ *   additive-term = multiplicative-term [("+" | "-") additive-term]
  *
- *   relational-term = additive-term [("&lt;" | &lt;=" | "&gt;" | &gt;=") additive-term]
+ *   relational-term = additive-term [("&lt;" | &lt;=" | "&gt;" | &gt;=") relational-term]
  *
- *   equality-term = relational-term [("==" | "!=") relational-term]
+ *   equality-term = relational-term [("==" | "!=") equality-term]
  *
- *   and-term = equality-term ["&amp;&amp;" equality-term]
+ *   and-term = equality-term ["&amp;&amp;" and-term]
  *
- *   or-term = and-term ["||" and-term]
+ *   or-term = and-term ["||" or-term]
  *
  *   expression = or-term
  *

--- a/src/main/java/au/com/codeka/carrot/expr/binary/BinaryTermParser.java
+++ b/src/main/java/au/com/codeka/carrot/expr/binary/BinaryTermParser.java
@@ -24,7 +24,7 @@ public final class BinaryTermParser implements TermParser {
   public Term parse(Tokenizer tokenizer) throws CarrotException {
     Term left = termParser.parse(tokenizer);
     if (tokenizer.accept(tokenTypes)) {
-      return new BinaryTerm(left, tokenizer.expect(tokenTypes).getType().binaryOperator(), termParser.parse(tokenizer));
+      return new BinaryTerm(left, tokenizer.expect(tokenTypes).getType().binaryOperator(), this.parse(tokenizer));
     }
     return left;
   }

--- a/src/main/java/au/com/codeka/carrot/expr/unary/UnaryTermParser.java
+++ b/src/main/java/au/com/codeka/carrot/expr/unary/UnaryTermParser.java
@@ -23,7 +23,7 @@ public final class UnaryTermParser implements TermParser {
   @Override
   public Term parse(Tokenizer tokenizer) throws CarrotException {
     if (tokenizer.accept(tokenTypes)) {
-      return new UnaryTerm(tokenizer.expect(tokenTypes).getType().unaryOperator(), termParser.parse(tokenizer));
+      return new UnaryTerm(tokenizer.expect(tokenTypes).getType().unaryOperator(), this.parse(tokenizer));
     }
     return termParser.parse(tokenizer);
   }

--- a/src/test/java/au/com/codeka/carrot/expr/StatementParserTest.java
+++ b/src/test/java/au/com/codeka/carrot/expr/StatementParserTest.java
@@ -1,6 +1,9 @@
 package au.com.codeka.carrot.expr;
 
 import au.com.codeka.carrot.CarrotException;
+import au.com.codeka.carrot.Configuration;
+import au.com.codeka.carrot.Scope;
+import au.com.codeka.carrot.bindings.EmptyBindings;
 import au.com.codeka.carrot.resource.ResourcePointer;
 import au.com.codeka.carrot.util.LineReader;
 import org.junit.Test;
@@ -34,6 +37,18 @@ public class StatementParserTest {
     parser = createStatementParser("a.b(1, 2)");
     var = parser.parseVariable();
     assertThat(var.toString()).isEqualTo("a DOT b LPAREN 1 COMMA 2 RPAREN");
+  }
+
+
+  @Test
+  public void testBinaryOperation() throws CarrotException {
+    assertThat(createStatementParser("1+1").parseExpression().evaluate(new Configuration(), new Scope(new EmptyBindings()))).isEqualTo(2);
+    assertThat(createStatementParser("1+1+1").parseExpression().evaluate(new Configuration(), new Scope(new EmptyBindings()))).isEqualTo(3);
+    assertThat(createStatementParser("1+1+1+1").parseExpression().evaluate(new Configuration(), new Scope(new EmptyBindings()))).isEqualTo(4);
+    assertThat(createStatementParser("1").parseExpression().evaluate(new Configuration(), new Scope(new EmptyBindings()))).isEqualTo(1);
+    assertThat(createStatementParser("!1").parseExpression().evaluate(new Configuration(), new Scope(new EmptyBindings()))).isEqualTo(false);
+    assertThat(createStatementParser("!!1").parseExpression().evaluate(new Configuration(), new Scope(new EmptyBindings()))).isEqualTo(true);
+    assertThat(createStatementParser("!!!1").parseExpression().evaluate(new Configuration(), new Scope(new EmptyBindings()))).isEqualTo(false);
   }
 
   private StatementParser createStatementParser(String str) throws CarrotException {


### PR DESCRIPTION
The right part of a binary term should be allowed to be of the same type, like in `1 + 2 + 3`. In this case `2 + 3` is the right side of the first term.

Same goes for an unary term in which the value can be an unary term as well, like in `!!a`