### PR TITLE
Next stage in refactoring expression parsing.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ repositories {
 
 dependencies {
     compile 'com.google.code.findbugs:jsr305:3.0.1'
+    compile 'org.dmfs:iterators:1.5'    // provides Flattened and SingletonIterator
     compileOnly 'org.json:json:20170516'
     testCompile 'junit:junit:4.12'
     testCompile 'com.google.truth:truth:0.31'

--- a/src/main/java/au/com/codeka/carrot/bindings/IterableExpansionBindings.java
+++ b/src/main/java/au/com/codeka/carrot/bindings/IterableExpansionBindings.java
@@ -5,7 +5,9 @@ import au.com.codeka.carrot.expr.Identifier;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 
 /**
  * {@link Bindings} which expand an {@link Iterable} into multiple variables (given in an {@link Iterable} as well).
@@ -21,29 +23,27 @@ import java.util.Iterator;
  * @author Marten Gajda
  */
 public final class IterableExpansionBindings implements Bindings {
-  private final Iterable<Identifier> identifiers;
-  private final Iterable<Object> values;
+  private final Map<String, Object> map = new HashMap<>();
 
   public IterableExpansionBindings(Iterable<Identifier> identifiers, Iterable<Object> values) {
-    this.identifiers = identifiers;
-    this.values = values;
+    // map the identifiers eagerly, otherwise the swap operation doesn't seem to work as expected
+    Iterator<Object> valueIterator = values.iterator();
+    for (Identifier identifier : identifiers) {
+      if (!valueIterator.hasNext()) {
+        break;
+      }
+      map.put(identifier.evaluate(), valueIterator.next());
+    }
   }
 
   @Nullable
   @Override
   public Object resolve(@Nonnull String key) {
-    Iterator<Object> values = this.values.iterator();
-    for (Identifier identifier : identifiers) {
-      Object nextValue = values.next();
-      if (key.equals(identifier.evaluate())) {
-        return nextValue;
-      }
-    }
-    return null;
+    return map.get(key);
   }
 
   @Override
   public boolean isEmpty() {
-    return !values.iterator().hasNext();
+    return map.isEmpty();
   }
 }

--- a/src/main/java/au/com/codeka/carrot/expr/EmptyTerm.java
+++ b/src/main/java/au/com/codeka/carrot/expr/EmptyTerm.java
@@ -1,0 +1,24 @@
+package au.com.codeka.carrot.expr;
+
+import au.com.codeka.carrot.CarrotException;
+import au.com.codeka.carrot.Configuration;
+import au.com.codeka.carrot.Scope;
+
+import java.util.Collections;
+
+/**
+ * An empty {@link Term}. Empty terms always evaluate to an empty {@link Iterable}.
+ *
+ * @author Marten Gajda
+ */
+public class EmptyTerm implements Term {
+  @Override
+  public Object evaluate(Configuration config, Scope scope) throws CarrotException {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public String toString() {
+    return "";
+  }
+}

--- a/src/main/java/au/com/codeka/carrot/expr/Function.java
+++ b/src/main/java/au/com/codeka/carrot/expr/Function.java
@@ -9,15 +9,16 @@ import javax.annotation.Nullable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A function identifier and a list of arguments to that function. See {@link StatementParser} for the full EBNF.
  */
 public class Function {
   private final Identifier funcName;
-  private final ArrayList<Expression> args;
+  private final Term args;
 
-  private Function(Identifier funcName, ArrayList<Expression> args) {
+  public Function(Identifier funcName, Term args) {
     this.funcName = funcName;
     this.args = args;
   }
@@ -25,12 +26,7 @@ public class Function {
   @Override
   public String toString() {
     String str = funcName.toString() + " " + TokenType.LPAREN + " ";
-    for (int i = 0; i < args.size(); i++) {
-      if (i > 0) {
-        str += " " + TokenType.COMMA + " ";
-      }
-      str += args.get(i).toString();
-    }
+    str += args.toString();
     str += " " + TokenType.RPAREN;
     return str;
   }
@@ -38,26 +34,26 @@ public class Function {
   /**
    * Evaluate this function on the given object, with the given {@link Configuration} and {@link Scope}.
    *
-   * @param value The value to evaluate this function on. That is, the object on which we want to call the function
-   *              this object represents.
+   * @param value  The value to evaluate this function on. That is, the object on which we want to call the function
+   *               this object represents.
    * @param config The current {@link Configuration}.
-   * @param scope The current {@link Scope}.
+   * @param scope  The current {@link Scope}.
    * @return The result of calling the function (i.e. the function's return value).
    * @throws CarrotException if there's any exceptions calling the function.
    */
   public Object evaluate(Object value, Configuration config, Scope scope) throws CarrotException {
-    Class<?>[] paramTypes = new Class<?>[args.size()];
-    Object[] paramValues = new Object[args.size()];
-    for (int i = 0; i < args.size(); i++) {
-      Object arg = args.get(i).evaluate(config, scope);
-      paramTypes[i] = arg.getClass();
-      paramValues[i] = arg;
+
+    List<Class<?>> paramTypes = new ArrayList<>();
+    List<Object> paramValues = new ArrayList<>();
+    for (Object p : (Iterable<Object>) args.evaluate(config, scope)) {
+      paramTypes.add(p.getClass());
+      paramValues.add(p);
     }
 
     try {
       Method method = findMethod(config, value.getClass(), funcName.evaluate(), paramTypes, paramValues);
       method.setAccessible(true);
-      return method.invoke(value, paramValues);
+      return method.invoke(value, paramValues.toArray());
     } catch (InvocationTargetException | IllegalAccessException e) {
       throw new CarrotException(e); // TODO: getPointer()
     }
@@ -70,12 +66,12 @@ public class Function {
    * if there's a method that takes an int and one that takes a long (say), we make no guarantee about which one will
    * be returned.</p>
    *
-   * @param config The {@link Configuration}.
-   * @param cls The {@link Class} to search for a method for.
-   * @param name The name of the function we want to search for (not case sensitive, unlike normal Java).
-   * @param paramTypes The types of the parameters we have. We'll attempt to find a method that matches the given
-   *                   types as closely as possible (for example, a method that takes an int is as good as one that
-   *                   takes longs).
+   * @param config      The {@link Configuration}.
+   * @param cls         The {@link Class} to search for a method for.
+   * @param name        The name of the function we want to search for (not case sensitive, unlike normal Java).
+   * @param paramTypes  The types of the parameters we have. We'll attempt to find a method that matches the given
+   *                    types as closely as possible (for example, a method that takes an int is as good as one that
+   *                    takes longs).
    * @param paramValues The values we're going to execute. If the types don't match exactly, we may need to convert
    *                    some of the parameters first.
    * @return The {@link Method} that matches the given name and parameter values.
@@ -85,8 +81,8 @@ public class Function {
       Configuration config,
       Class<?> cls,
       String name,
-      Class<?>[] paramTypes,
-      Object[] paramValues) throws CarrotException {
+      List<Class<?>> paramTypes,
+      List<Object> paramValues) throws CarrotException {
 
     // This is a list of "candidate" methods that we tried and rejected for whatever reason. Useful in the error
     // message that we throw if there's no perfect method.
@@ -98,21 +94,21 @@ public class Function {
 
       Class<?>[] methodParamTypes = method.getParameterTypes();
 
-      if (methodParamTypes.length != paramTypes.length) {
-        Log.debug(config, "Wrong number of arguments: %d: %s", paramTypes.length, method);
+      if (methodParamTypes.length != paramTypes.size()) {
+        Log.debug(config, "Wrong number of arguments: %d: %s", paramTypes.size(), method);
         candidates.add(method.toString());
         continue;
       }
 
       boolean allMatch = true;
       for (int i = 0; i < methodParamTypes.length; i++) {
-        if (!methodParamTypes[i].isAssignableFrom(paramTypes[i])) {
-          Object convertedValue = convertType(methodParamTypes[i], paramValues[i]);
+        if (!methodParamTypes[i].isAssignableFrom(paramTypes.get(i))) {
+          Object convertedValue = convertType(methodParamTypes[i], paramValues.get(i));
           if (convertedValue != null) {
-            paramValues[i] = convertedValue;
+            paramValues.set(i, convertedValue);
           } else {
             Log.debug(config,
-                "Param %d (%s) not assignable from %s: %s", i, methodParamTypes[i], paramTypes[i], method);
+                "Param %d (%s) not assignable from %s: %s", i, methodParamTypes[i], paramTypes.get(i), method);
             candidates.add(method.toString());
             allMatch = false;
             break;
@@ -121,7 +117,7 @@ public class Function {
       }
       if (allMatch) {
         for (int i = 0; i < methodParamTypes.length; i++) {
-          paramValues[i] = convertType(method.getParameterTypes()[i], paramValues[i]);
+          paramValues.set(i, convertType(method.getParameterTypes()[i], paramValues.get(i)));
         }
         return method;
       }
@@ -137,7 +133,7 @@ public class Function {
    * Attempts to perform a conversion from the given value to the given output type.
    *
    * @param outputType The output type that we want.
-   * @param value The value that we want to convert.
+   * @param value      The value that we want to convert.
    * @return The converted value, or null if no conversion is possible.
    */
   @Nullable
@@ -171,41 +167,5 @@ public class Function {
     }
 
     return null;
-  }
-
-  /**
-   * Simple builder class for {@link Function}.
-   */
-  public static class Builder {
-    private final Identifier funcName;
-    private final ArrayList<Expression> args;
-
-    /**
-     * Construct a new {@link Builder} for a function with the given {@link Identifier} as it's name.
-     *
-     * @param funcName The name of this function.
-     */
-    public Builder(Identifier funcName) {
-      this.funcName = funcName;
-      this.args = new ArrayList<>();
-    }
-
-    /**
-     * Add the given {@link Expression} as an argument to the function.
-     *
-     * @param arg The {@link Expression} to add as an argument.
-     * @return This {@link Builder}.
-     */
-    public Builder addParam(Expression arg) {
-      this.args.add(arg);
-      return this;
-    }
-
-    /**
-     * @return The built {@link Function}.
-     */
-    public Function build() {
-      return new Function(funcName, args);
-    }
   }
 }

--- a/src/main/java/au/com/codeka/carrot/expr/TokenType.java
+++ b/src/main/java/au/com/codeka/carrot/expr/TokenType.java
@@ -13,67 +13,75 @@ public enum TokenType {
   /**
    * An unknown token, or the end of the stream.
    */
-  EOF(false, null, null),
+  EOF(false),
 
   /**
    * A string literal "like this".
    */
-  STRING_LITERAL(true, null, null),
+  STRING_LITERAL(true),
 
   /**
    * A number literal, like 12 or 12.34.
    */
-  NUMBER_LITERAL(true, null, null),
+  NUMBER_LITERAL(true),
 
   /**
    * A Java-style identifier like foo or bar.
    */
-  IDENTIFIER(true, null, null),
+  IDENTIFIER(true),
 
   /**
    * Left-parenthesis: (
    */
-  LPAREN(false, null, null),
+  LPAREN(false),
 
   /**
-   * Right-parenthesis: (
+   * Right-parenthesis: )
    */
-  RPAREN(false, null, null),
+  RPAREN(false),
 
   /**
    * Left-square-bracket: [
    */
-  LSQUARE(false, null, null),
+  LSQUARE(false),
 
   /**
    * Right-square-bracket: ]
    */
-  RSQUARE(false, null, null),
+  RSQUARE(false),
 
   /**
    * Single Equals: =
    */
-  ASSIGNMENT(false, null, null),
+  ASSIGNMENT(false),
 
-  COMMA(false, null, null),
-  DOT(false, null, null),
+  COMMA(false, new IterationOperator()),
+  DOT(false),
   NOT(false, null, new NotOperator()),
-  LOGICAL_AND(false, new AndOperator(), null),
-  LOGICAL_OR(false, new OrOperator(), null),
-  EQUALITY(false, new EqOperator(), null),
-  INEQUALITY(false, new Complement(EQUALITY.binaryOperator), null),
-  LESS_THAN(false, new LessOperator(), null),
-  GREATER_THAN(false, new GreaterOperator(), null),
-  LESS_THAN_OR_EQUAL(false, new Complement(GREATER_THAN.binaryOperator), null),
-  GREATER_THAN_OR_EQUAL(false, new Complement(LESS_THAN.binaryOperator), null),
+  LOGICAL_AND(false, new AndOperator()),
+  LOGICAL_OR(false, new OrOperator()),
+  EQUALITY(false, new EqOperator()),
+  INEQUALITY(false, new Complement(EQUALITY.binaryOperator)),
+  LESS_THAN(false, new LessOperator()),
+  GREATER_THAN(false, new GreaterOperator()),
+  LESS_THAN_OR_EQUAL(false, new Complement(GREATER_THAN.binaryOperator)),
+  GREATER_THAN_OR_EQUAL(false, new Complement(LESS_THAN.binaryOperator)),
   PLUS(false, new AddOperator(), new PlusOperator()),
   MINUS(false, new SubOperator(), new MinusOperator()),
-  MULTIPLY(false, new MulOperator(), null),
-  DIVIDE(false, new DivOperator(), null);
+  MULTIPLY(false, new MulOperator()),
+  DIVIDE(false, new DivOperator());
 
   private final boolean hasValue;
   private final BinaryOperator binaryOperator;
   private final UnaryOperator unaryOperator;
+
+  TokenType(boolean hasValue) {
+    this(hasValue, null, null);
+  }
+
+  TokenType(boolean hasValue, BinaryOperator binaryOperator) {
+    this(hasValue, binaryOperator, null);
+  }
 
   TokenType(boolean hasValue, BinaryOperator binaryOperator, UnaryOperator unaryOperator) {
     this.hasValue = hasValue;

--- a/src/main/java/au/com/codeka/carrot/expr/binary/IterableTerm.java
+++ b/src/main/java/au/com/codeka/carrot/expr/binary/IterableTerm.java
@@ -1,0 +1,31 @@
+package au.com.codeka.carrot.expr.binary;
+
+import au.com.codeka.carrot.CarrotException;
+import au.com.codeka.carrot.Configuration;
+import au.com.codeka.carrot.Scope;
+import au.com.codeka.carrot.expr.Term;
+
+import java.util.Collections;
+
+/**
+ * Adapter which makes the evaluated value of a {@link Term} {@link Iterable}.
+ *
+ * @author Marten Gajda
+ */
+public class IterableTerm implements Term {
+  private final Term left;
+
+  public IterableTerm(Term left) {
+    this.left = left;
+  }
+
+  @Override
+  public Object evaluate(Configuration config, Scope scope) throws CarrotException {
+    return Collections.singleton(left.evaluate(config, scope));
+  }
+
+  @Override
+  public String toString() {
+    return left.toString();
+  }
+}

--- a/src/main/java/au/com/codeka/carrot/expr/binary/IterationOperator.java
+++ b/src/main/java/au/com/codeka/carrot/expr/binary/IterationOperator.java
@@ -1,0 +1,53 @@
+package au.com.codeka.carrot.expr.binary;
+
+import au.com.codeka.carrot.CarrotException;
+import au.com.codeka.carrot.expr.Lazy;
+import au.com.codeka.carrot.expr.TokenType;
+import org.dmfs.iterables.decorators.Flattened;
+import org.dmfs.iterators.SingletonIterator;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.Iterator;
+
+/**
+ * The binary ITERATION operator like in {@code a, b}.
+ *
+ * @author Marten Gajda
+ */
+public final class IterationOperator implements BinaryOperator {
+  @Override
+  public Object apply(Object left, Lazy right) throws CarrotException {
+    return new Flattened<>(Collections.singleton(left), new LazyIterable(right));
+  }
+
+  @Override
+  public String toString() {
+    return TokenType.COMMA.toString();
+  }
+
+
+  /**
+   * An {@link Iterable} which flattens the value of the right hand side of an IterableOperator.
+   */
+  private final class LazyIterable implements Iterable<Object> {
+    private final Lazy value;
+
+    public LazyIterable(Lazy value) {
+      this.value = value;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Nonnull
+    @Override
+    public Iterator<Object> iterator() {
+      try {
+        Object val = value.value();
+        return val instanceof Iterable ? ((Iterable) val).iterator() : new SingletonIterator<>(val);
+      } catch (CarrotException e) {
+        // TODO: find more appropriate exception
+        throw new IllegalStateException("can't iterate elements", e);
+      }
+    }
+  }
+}

--- a/src/main/java/au/com/codeka/carrot/expr/binary/LaxIterationTermParser.java
+++ b/src/main/java/au/com/codeka/carrot/expr/binary/LaxIterationTermParser.java
@@ -1,0 +1,33 @@
+package au.com.codeka.carrot.expr.binary;
+
+import au.com.codeka.carrot.CarrotException;
+import au.com.codeka.carrot.expr.*;
+
+/**
+ * A factory for iterable {@link Term}s. If the term does not contain a {@code ,} this will return the sole term as is
+ * and not as an {@link java.util.Iterator} Use {@link StrictIterationTermParser} if you always need an iterator, even for single terms.
+ *
+ * @author Marten Gajda
+ */
+public final class LaxIterationTermParser implements TermParser {
+  private final TermParser termParser;
+  private final TermParser iterationTermParser;
+
+  public LaxIterationTermParser(TermParser termParser) {
+    this.termParser = termParser;
+    this.iterationTermParser = new StrictIterationTermParser(termParser);
+  }
+
+  @Override
+  public Term parse(Tokenizer tokenizer) throws CarrotException {
+    Term left = termParser.parse(tokenizer);
+    if (tokenizer.accept(TokenType.COMMA)) {
+      // consume the comma
+      tokenizer.expect(TokenType.COMMA);
+      // We're in an iteration, parse all remaining elements with the strict parser
+      Term right = iterationTermParser.parse(tokenizer);
+      return right instanceof EmptyTerm ? new IterableTerm(left) : new BinaryTerm(left, TokenType.COMMA.binaryOperator(), right);
+    }
+    return left;
+  }
+}

--- a/src/main/java/au/com/codeka/carrot/expr/binary/StrictIterationTermParser.java
+++ b/src/main/java/au/com/codeka/carrot/expr/binary/StrictIterationTermParser.java
@@ -1,0 +1,33 @@
+package au.com.codeka.carrot.expr.binary;
+
+import au.com.codeka.carrot.CarrotException;
+import au.com.codeka.carrot.expr.*;
+
+/**
+ * A factory for iterable {@link Term}s.
+ * <p>
+ * Note, this *always* returns a term which evaluates to an {@link Iterable}, even if no comma is present. This is
+ * different from using a {@link LaxIterationTermParser} which will
+ * return a singla scalar if the term is not an iteration of values.
+ *
+ * @author Marten Gajda
+ */
+public final class StrictIterationTermParser implements TermParser {
+  private final TermParser termParser;
+
+  public StrictIterationTermParser(TermParser termParser) {
+    this.termParser = termParser;
+  }
+
+  @Override
+  public Term parse(Tokenizer tokenizer) throws CarrotException {
+    Term left = termParser.parse(tokenizer);
+    if (tokenizer.accept(TokenType.COMMA)) {
+      // consume the comma
+      tokenizer.expect(TokenType.COMMA);
+      Term right = this.parse(tokenizer);
+      return right instanceof EmptyTerm ? new IterableTerm(left) : new BinaryTerm(left, TokenType.COMMA.binaryOperator(), right);
+    }
+    return left instanceof EmptyTerm ? left : new IterableTerm(left);
+  }
+}

--- a/src/test/java/au/com/codeka/carrot/CarrotEngineTest.java
+++ b/src/test/java/au/com/codeka/carrot/CarrotEngineTest.java
@@ -39,10 +39,17 @@ public class CarrotEngineTest {
   }
 
   @Test
+  public void testIterationLoopAndConditionalsTag() {
+    assertThat(render("{% for a in \"foo\", \"bar\", \"baz\" %}{{ a }}{{ !loop.last && \", \" || \"\" }}{% end %}", new EmptyBindings())).isEqualTo("foo, bar, baz");
+  }
+
+  @Test
   public void testOperatorPrecdence() {
     Map<String, Object> context = ImmutableMap.of("true", (Object) true, "false", false);
 
     assertThat(render("{{ 1 + 1 * 2 }}", new MapBindings(context))).isEqualTo("3");
+    assertThat(render("{{ 1 + 2 * 4 + 10 }}", new MapBindings(context))).isEqualTo("19");
+    assertThat(render("{{ 1 + 1 + 1 * 2 }}", new MapBindings(context))).isEqualTo("4");
     assertThat(render("{{ (1 + 1) * 2 }}", new MapBindings(context))).isEqualTo("4");
     assertThat(render("{{ 2 * 2 + 2 }}", new MapBindings(context))).isEqualTo("6");
     assertThat(render("{{ 2 * (2 + 2) }}", new MapBindings(context))).isEqualTo("8");

--- a/src/test/java/au/com/codeka/carrot/expr/FunctionTest.java
+++ b/src/test/java/au/com/codeka/carrot/expr/FunctionTest.java
@@ -11,7 +11,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.io.StringReader;
-import java.util.HashMap;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
@@ -23,7 +22,7 @@ import static org.junit.Assert.fail;
 public class FunctionTest {
   @Test
   public void testMethodNotFound() {
-    Function f = new Function.Builder(new Identifier(new Token(TokenType.IDENTIFIER, "foo"))).build();
+    Function f = new Function(new Identifier(new Token(TokenType.IDENTIFIER, "foo")), new EmptyTerm());
     try {
       f.evaluate(new Object(), new Configuration(), new Scope(new EmptyBindings()));
       fail("CarrotException expected.");
@@ -34,9 +33,7 @@ public class FunctionTest {
 
   @Test
   public void testWrongNumberOfParameters() {
-    Function f = new Function.Builder(new Identifier(new Token(TokenType.IDENTIFIER, "foo")))
-        .addParam(parseExpression("12"))
-        .build();
+    Function f = new Function(new Identifier(new Token(TokenType.IDENTIFIER, "foo")), parseExpression("12"));
 
     try {
       f.evaluate(new FooWithTwoArgs(), new Configuration(), new Scope(new EmptyBindings()));
@@ -50,10 +47,7 @@ public class FunctionTest {
 
   @Test
   public void testInconvertibleTypes() {
-    Function f = new Function.Builder(new Identifier(new Token(TokenType.IDENTIFIER, "foo")))
-        .addParam(parseExpression("\"Hello\""))
-        .addParam(parseExpression("\"World\""))
-        .build();
+    Function f = new Function(new Identifier(new Token(TokenType.IDENTIFIER, "foo")),parseExpression("\"Hello\", \"World\""));
 
     try {
       f.evaluate(new FooWithTwoArgs(), new Configuration(), new Scope(new EmptyBindings()));
@@ -71,10 +65,10 @@ public class FunctionTest {
     }
   }
 
-  private Expression parseExpression(String expr) {
+  private Term parseExpression(String expr) {
     try {
       return new StatementParser(
-          new Tokenizer(new LineReader(new ResourcePointer(null), new StringReader(expr)))).parseExpression();
+          new Tokenizer(new LineReader(new ResourcePointer(null), new StringReader(expr)))).parseTermsIterable();
     } catch (CarrotException e) {
       fail(e.getMessage());
       throw new RuntimeException(); // Won't get here.

--- a/src/test/java/au/com/codeka/carrot/expr/StatementParserTest.java
+++ b/src/test/java/au/com/codeka/carrot/expr/StatementParserTest.java
@@ -51,6 +51,15 @@ public class StatementParserTest {
     assertThat(createStatementParser("!!!1").parseExpression().evaluate(new Configuration(), new Scope(new EmptyBindings()))).isEqualTo(false);
   }
 
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testIterableTerms() throws CarrotException {
+    assertThat((Iterable<Object>) createStatementParser("1, 2").parseTermsIterable().evaluate(new Configuration(), new Scope(new EmptyBindings()))).containsAllOf(1L, 2L);
+    assertThat((Iterable<Object>) createStatementParser("1, 2, 3").parseTermsIterable().evaluate(new Configuration(), new Scope(new EmptyBindings()))).containsAllOf(1L, 2L, 3L);
+    assertThat((Iterable<Object>) createStatementParser("1, 2 + 5, \"3\", 4").parseTermsIterable().evaluate(new Configuration(), new Scope(new EmptyBindings()))).containsAllOf(1L, 7L, "3", 4L);
+  }
+
+
   private StatementParser createStatementParser(String str) throws CarrotException {
     return new StatementParser(new Tokenizer(new LineReader(new ResourcePointer(null), new StringReader(str))));
   }

--- a/src/test/java/au/com/codeka/carrot/tag/ForTagTest.java
+++ b/src/test/java/au/com/codeka/carrot/tag/ForTagTest.java
@@ -3,6 +3,7 @@ package au.com.codeka.carrot.tag;
 import au.com.codeka.carrot.CarrotEngine;
 import au.com.codeka.carrot.CarrotException;
 import au.com.codeka.carrot.Configuration;
+import au.com.codeka.carrot.bindings.EmptyBindings;
 import au.com.codeka.carrot.bindings.MapBindings;
 import au.com.codeka.carrot.resource.MemoryResourceLocator;
 import org.junit.Test;
@@ -50,6 +51,28 @@ public class ForTagTest {
     assertThat(render("Hello {% for x, y, z in values %} -{{ x }}/{{ y }}/{{ z }}- {% end %} World", context))
         .isEqualTo("Hello  -foo/bar/baz-  -1/2/3-  -a/b/c-  World");
   }
+
+  @Test
+  public void testIterableLoop() throws CarrotException {
+    Map<String, Object> context = new HashMap<>();
+    assertThat(render("Hello {% for a in 1, 2, 3 %} -{{ a }}- {% end %} World", context))
+        .isEqualTo("Hello  -1-  -2-  -3-  World");
+  }
+
+  @Test
+  public void testIterableLoopExpansion() throws CarrotException {
+    Map<String, Object> context = new HashMap<>();
+    assertThat(render("Hello {% for number, letter in (1, \"a\"), (2, \"b\"), (3, \"c\") %} {{ number }}:{{ letter }} {% end %} World", context))
+        .isEqualTo("Hello  1:a  2:b  3:c  World");
+  }
+
+  @Test
+  public void testSingleLoopExpansion() throws CarrotException {
+    assertThat(render("Hello {% for number in 1,  %} {{ number }} {% end %} World", new HashMap<String, Object>())).isEqualTo("Hello  1  World");
+    assertThat(render("Hello {% for number in 1, 2 %} {{ number }} {% end %} World", new HashMap<String, Object>())).isEqualTo("Hello  1  2  World");
+    assertThat(render("Hello {% for number in 1, 2, %} {{ number }} {% end %} World", new HashMap<String, Object>())).isEqualTo("Hello  1  2  World");
+  }
+
 
   @Test
   public void testMapExpansionLoop() throws CarrotException {

--- a/src/test/java/au/com/codeka/carrot/tag/SetTagHelper.java
+++ b/src/test/java/au/com/codeka/carrot/tag/SetTagHelper.java
@@ -45,4 +45,18 @@ public class SetTagHelper {
         .isEqualTo("foo=bing, bar=bong");
   }
 
+
+  @Test
+  public void testIterableExpansion() throws CarrotException {
+    assertThat(render("{% set foo, bar = \"bing\", \"bong\" %}foo={{ foo }}, bar={{ bar }}"))
+        .isEqualTo("foo=bing, bar=bong");
+  }
+
+  @Test
+  public void testSwap() throws CarrotException {
+    assertThat(render("{% set foo, bar = \"bing\", \"bong\" %}{% set foo, bar = bar, foo %}foo={{ foo }}, bar={{ bar }}"))
+        .isEqualTo("foo=bong, bar=bing");
+    assertThat(render("{% set foo, bar, baz = \"bing\", \"bong\", \"bang\" %}{% set foo, bar, baz = bar, baz, foo %}foo={{ foo }}, bar={{ bar }}, baz={{ baz }}"))
+        .isEqualTo("foo=bong, bar=bang, baz=bing");
+  }
 }


### PR DESCRIPTION
Next stage in refactoring expression parsing.
    
This commit introduces "Iterations" which is just a comma separated list of terms. Function parameters are parsed as iterations now too.
    
You can use them in various places, e.g.
    
**Set multiple values in a single `set` statement**
```
{% set foo, bar = "bing", "bong" %}
```
This sets `foo="bing"` and `bar="bong"`.
    
**Swap two (or more) values**
```
{% set foo, bar = bar, foo %}
{% set foo, bar, baz = bar, baz, foo %}
```
    
**Iterate over multiple values**
```
{% for a in 1, 2, 3 %} -{{ a }}- {% end %}
```
This results in ` -1-  -2-  -3- `
   
**Iterate over multiple iterables**
```
{% for number, letter in (1, "a"), (2, "b"), (3, "c") %} {{ number }}:{{ letter }} {% end %}
```
This results in ` 1:a  2:b  3:c `
   
Iterations behave pretty much like tuples in Python, i.e. `a` or `(a)` is a scalar (not iterable unless `a` iteself is iterable), `a,` or `(a,)` is an Iterable with a single value `a`, `(a,b)` is an iterable with two values `a` and `b`, etc
    
Note, this commit adds a library of ours which we use for the `Flattened` and `SingletonIterator` iterators.
    
TODO: refactor StrictIterationTermParser and LaxIterationTermParser. Both share a lot of code.