### PR TITLE
Add support for Python-style `not`, `and` and `or` operators as alter…

### DIFF
--- a/src/main/java/au/com/codeka/carrot/expr/EmptyTerm.java
+++ b/src/main/java/au/com/codeka/carrot/expr/EmptyTerm.java
@@ -11,7 +11,7 @@ import java.util.Collections;
  *
  * @author Marten Gajda
  */
-public class EmptyTerm implements Term {
+public final class EmptyTerm implements Term {
   @Override
   public Object evaluate(Configuration config, Scope scope) throws CarrotException {
     return Collections.emptyList();

--- a/src/main/java/au/com/codeka/carrot/expr/StatementParser.java
+++ b/src/main/java/au/com/codeka/carrot/expr/StatementParser.java
@@ -31,7 +31,7 @@ import java.util.List;
  *
  *   additive-term = multiplicative-term [("+" | "-") additive-term]
  *
- *   relational-term = additive-term [("&lt;" | &lt;=" | "&gt;" | &gt;=") relational-term]
+ *   relational-term = additive-term [("&lt;" | &lt;=" | "&gt;" | &gt;=" | "in") relational-term]
  *
  *   equality-term = relational-term [("==" | "!=") equality-term]
  *
@@ -82,7 +82,7 @@ public class StatementParser {
                                 TokenType.NOT),
                             TokenType.MULTIPLY, TokenType.DIVIDE),
                         TokenType.PLUS, TokenType.MINUS),
-                    TokenType.LESS_THAN, TokenType.LESS_THAN_OR_EQUAL, TokenType.GREATER_THAN, TokenType.GREATER_THAN_OR_EQUAL),
+                    TokenType.LESS_THAN, TokenType.LESS_THAN_OR_EQUAL, TokenType.GREATER_THAN, TokenType.GREATER_THAN_OR_EQUAL, TokenType.IN),
                 TokenType.EQUALITY, TokenType.INEQUALITY),
             TokenType.LOGICAL_AND),
         TokenType.LOGICAL_OR);
@@ -119,6 +119,11 @@ public class StatementParser {
 
   public Identifier parseIdentifier() throws CarrotException {
     return new Identifier(tokenizer.expect(TokenType.IDENTIFIER));
+  }
+
+
+  public Token parseToken(TokenType type) throws CarrotException {
+    return tokenizer.expect(type);
   }
 
   public List<Identifier> parseIdentifierList() throws CarrotException {

--- a/src/main/java/au/com/codeka/carrot/expr/TokenType.java
+++ b/src/main/java/au/com/codeka/carrot/expr/TokenType.java
@@ -69,7 +69,8 @@ public enum TokenType {
   PLUS(false, new AddOperator(), new PlusOperator()),
   MINUS(false, new SubOperator(), new MinusOperator()),
   MULTIPLY(false, new MulOperator()),
-  DIVIDE(false, new DivOperator());
+  DIVIDE(false, new DivOperator()),
+  IN(false, new InOperator());
 
   private final boolean hasValue;
   private final BinaryOperator binaryOperator;

--- a/src/main/java/au/com/codeka/carrot/expr/Tokenizer.java
+++ b/src/main/java/au/com/codeka/carrot/expr/Tokenizer.java
@@ -259,7 +259,22 @@ public class Tokenizer {
           if (next > 0) {
             lookahead = (char) next;
           }
-          token = new Token(TokenType.IDENTIFIER, identifier);
+          switch (identifier) {
+            case "or":
+              token = new Token(TokenType.LOGICAL_OR, identifier);
+              break;
+            case "and":
+              token = new Token(TokenType.LOGICAL_AND, identifier);
+              break;
+            case "not":
+              token = new Token(TokenType.NOT, identifier);
+              break;
+            case "in":
+              token = new Token(TokenType.IN, identifier);
+              break;
+            default:
+              token = new Token(TokenType.IDENTIFIER, identifier);
+          }
         } else {
           throw new CarrotException("Unexpected character: " + (char) ch, reader.getPointer());
         }

--- a/src/main/java/au/com/codeka/carrot/expr/binary/InOperator.java
+++ b/src/main/java/au/com/codeka/carrot/expr/binary/InOperator.java
@@ -1,0 +1,45 @@
+package au.com.codeka.carrot.expr.binary;
+
+import au.com.codeka.carrot.Bindings;
+import au.com.codeka.carrot.CarrotException;
+import au.com.codeka.carrot.expr.Lazy;
+import au.com.codeka.carrot.expr.TokenType;
+import org.dmfs.iterables.decorators.Filtered;
+import org.dmfs.iterators.filters.AnyOf;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * The binary IN operator like in {@code a in list}.
+ *
+ * @author Marten Gajda
+ */
+public final class InOperator implements BinaryOperator {
+  @Override
+  public Object apply(Object left, Lazy right) throws CarrotException {
+    Object rightValue = right.value();
+    if (rightValue instanceof Collection) {
+      return ((Collection) rightValue).contains(left);
+    }
+    if (rightValue instanceof Map) {
+      return ((Map) rightValue).containsKey(left);
+    }
+    if (rightValue instanceof Bindings) {
+      return ((Bindings) rightValue).resolve(left.toString()) != null;
+    }
+    if (rightValue instanceof Iterable) {
+      return new Filtered<>((Iterable<Object>) rightValue, new AnyOf<>(left)).iterator().hasNext();
+    }
+    // TODO: should we also test for members?
+
+    // TODO: would it be better to throw if you don't use it with a correct type?
+    return false;
+  }
+
+
+  @Override
+  public String toString() {
+    return TokenType.IN.toString();
+  }
+}

--- a/src/main/java/au/com/codeka/carrot/expr/binary/IterableTerm.java
+++ b/src/main/java/au/com/codeka/carrot/expr/binary/IterableTerm.java
@@ -12,7 +12,7 @@ import java.util.Collections;
  *
  * @author Marten Gajda
  */
-public class IterableTerm implements Term {
+public final class IterableTerm implements Term {
   private final Term left;
 
   public IterableTerm(Term left) {

--- a/src/main/java/au/com/codeka/carrot/tag/ForTag.java
+++ b/src/main/java/au/com/codeka/carrot/tag/ForTag.java
@@ -8,6 +8,7 @@ import au.com.codeka.carrot.bindings.SingletonBindings;
 import au.com.codeka.carrot.expr.Expression;
 import au.com.codeka.carrot.expr.Identifier;
 import au.com.codeka.carrot.expr.StatementParser;
+import au.com.codeka.carrot.expr.TokenType;
 import au.com.codeka.carrot.tmpl.Node;
 import au.com.codeka.carrot.tmpl.TagNode;
 
@@ -37,10 +38,7 @@ public class ForTag extends Tag {
   @Override
   public void parseStatement(StatementParser stmtParser) throws CarrotException {
     loopIdentifiers = stmtParser.parseIdentifierList();
-    Identifier inIdentifier = stmtParser.parseIdentifier();
-    if (!inIdentifier.evaluate().equalsIgnoreCase("in")) {
-      throw new CarrotException("Expected 'in'.");
-    }
+    stmtParser.parseToken(TokenType.IN);
     loopExpression = stmtParser.parseExpression();
   }
 

--- a/src/test/java/au/com/codeka/carrot/CarrotEngineTest.java
+++ b/src/test/java/au/com/codeka/carrot/CarrotEngineTest.java
@@ -59,15 +59,20 @@ public class CarrotEngineTest {
   @Test
   public void testConditionalStatements() {
     assertThat(render("{{ foo && \"a\" || \"b\"}}", new SingletonBindings("foo", true))).isEqualTo("a");
-
     assertThat(render("{{ foo && \"a\" || \"b\"}}", new SingletonBindings("foo", false))).isEqualTo("b");
     assertThat(render("{{ (foo && \"a\") || \"b\"}}", new SingletonBindings("foo", false))).isEqualTo("b");
-
     assertThat(render("{{ foo && \"a\"}}", new SingletonBindings("foo", true))).isEqualTo("a");
     assertThat(render("{{ foo && \"a\"}}", new SingletonBindings("foo", false))).isEqualTo("false");
-
     assertThat(render("{{ foo || \"a\"}}", new SingletonBindings("foo", true))).isEqualTo("true");
     assertThat(render("{{ foo || \"a\"}}", new SingletonBindings("foo", false))).isEqualTo("a");
+
+    assertThat(render("{{ foo and \"a\" or \"b\"}}", new SingletonBindings("foo", true))).isEqualTo("a");
+    assertThat(render("{{ foo and \"a\" or \"b\"}}", new SingletonBindings("foo", false))).isEqualTo("b");
+    assertThat(render("{{ (foo and \"a\") or \"b\"}}", new SingletonBindings("foo", false))).isEqualTo("b");
+    assertThat(render("{{ foo and \"a\"}}", new SingletonBindings("foo", true))).isEqualTo("a");
+    assertThat(render("{{ foo and \"a\"}}", new SingletonBindings("foo", false))).isEqualTo("false");
+    assertThat(render("{{ foo or \"a\"}}", new SingletonBindings("foo", true))).isEqualTo("true");
+    assertThat(render("{{ foo or \"a\"}}", new SingletonBindings("foo", false))).isEqualTo("a");
   }
 
   @Test

--- a/src/test/java/au/com/codeka/carrot/tag/IfTagTest.java
+++ b/src/test/java/au/com/codeka/carrot/tag/IfTagTest.java
@@ -5,6 +5,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.util.Arrays;
+
 import static au.com.codeka.carrot.util.RenderHelper.render;
 import static com.google.common.truth.Truth.assertThat;
 
@@ -125,6 +127,16 @@ public class IfTagTest {
     assertThat(render("{% if !foo %}yes{% else %}no{% end %}", "foo", true)).isEqualTo("no");
     assertThat(render("{% if !foo %}yes{% else %}no{% end %}", "foo", false)).isEqualTo("yes");
   }
+
+
+  @Test
+  public void testIfIn() throws CarrotException {
+    assertThat(render("{% if foo in (1,2,3) %}yes{% else %}no{% end %}", "foo", 2L)).isEqualTo("yes");
+    assertThat(render("{% if foo in (1,2,3) %}yes{% else %}no{% end %}", "foo", 4L)).isEqualTo("no");
+    assertThat(render("{% if foo in list %}yes{% else %}no{% end %}", "foo", 2,"list",Arrays.asList(1,2,3))).isEqualTo("yes");
+    assertThat(render("{% if foo in list %}yes{% else %}no{% end %}", "foo", 4,"list",Arrays.asList(1,2,3))).isEqualTo("no");
+  }
+
 
   @Test
   public void testNulls() throws CarrotException {


### PR DESCRIPTION
…natives to the C-style `!`, `&&` and `||`.

Also add support for the binary `in` operator.

General note regarding iterations: Although mostly not required, it's sometimes necessary to enclose them in parenthesis to enfore the correct evaluation order. `,` has the lowest precendece hence `a in 1, 2, 3` would be intepreted as `(a in 1), (2), (3)`, which is a non-empty iterable (and always evaluated to `true`).  The correct syntax is `a in (1, 2, 3)`.