### PR TITLE
Fix associativity of binary terms.

### DIFF
--- a/src/main/java/au/com/codeka/carrot/expr/binary/BinaryTermParser.java
+++ b/src/main/java/au/com/codeka/carrot/expr/binary/BinaryTermParser.java
@@ -23,8 +23,8 @@ public final class BinaryTermParser implements TermParser {
   @Override
   public Term parse(Tokenizer tokenizer) throws CarrotException {
     Term left = termParser.parse(tokenizer);
-    if (tokenizer.accept(tokenTypes)) {
-      return new BinaryTerm(left, tokenizer.expect(tokenTypes).getType().binaryOperator(), this.parse(tokenizer));
+    while (tokenizer.accept(tokenTypes)) {
+      left = new BinaryTerm(left, tokenizer.expect(tokenTypes).getType().binaryOperator(), termParser.parse(tokenizer));
     }
     return left;
   }

--- a/src/test/java/au/com/codeka/carrot/CarrotEngineTest.java
+++ b/src/test/java/au/com/codeka/carrot/CarrotEngineTest.java
@@ -45,16 +45,21 @@ public class CarrotEngineTest {
 
   @Test
   public void testOperatorPrecdence() {
-    Map<String, Object> context = ImmutableMap.of("true", (Object) true, "false", false);
-
-    assertThat(render("{{ 1 + 1 * 2 }}", new MapBindings(context))).isEqualTo("3");
-    assertThat(render("{{ 1 + 2 * 4 + 10 }}", new MapBindings(context))).isEqualTo("19");
-    assertThat(render("{{ 1 + 1 + 1 * 2 }}", new MapBindings(context))).isEqualTo("4");
-    assertThat(render("{{ (1 + 1) * 2 }}", new MapBindings(context))).isEqualTo("4");
-    assertThat(render("{{ 2 * 2 + 2 }}", new MapBindings(context))).isEqualTo("6");
-    assertThat(render("{{ 2 * (2 + 2) }}", new MapBindings(context))).isEqualTo("8");
+    assertThat(render("{{ 1 + 1 * 2 }}", new EmptyBindings())).isEqualTo("3");
+    assertThat(render("{{ 1 + 2 * 4 + 10 }}", new EmptyBindings())).isEqualTo("19");
+    assertThat(render("{{ 1 + 1 + 1 * 2 }}", new EmptyBindings())).isEqualTo("4");
+    assertThat(render("{{ (1 + 1) * 2 }}", new EmptyBindings())).isEqualTo("4");
+    assertThat(render("{{ 2 * 2 + 2 }}", new EmptyBindings())).isEqualTo("6");
+    assertThat(render("{{ 2 * (2 + 2) }}", new EmptyBindings())).isEqualTo("8");
   }
 
+
+
+  @Test
+  public void testOperatorAssociativity() {
+    assertThat(render("{{ 1200 / 20 / 5 }}", new EmptyBindings())).isEqualTo("12");
+    assertThat(render("{{ 10 - 5 - 3 }}", new EmptyBindings())).isEqualTo("2");
+  }
 
   @Test
   public void testConditionalStatements() {


### PR DESCRIPTION
Operators with the same precedence are usually evaluated left to right (with very few exceptions), see https://docs.oracle.com/javase/tutorial/java/nutsandbolts/operators.html

For instance the term `8 - 4 - 2` is commonly understood to be equivalent to `(8 - 4) - 2 == 2`.

However, before this commit the term had been parsed into the following tree:

```
      (-)
     /   \
    8    (-)
        /   \
       4     2
```

Which had been evaluated to `8 - (4 - 2) == 6`

With this commit it's parsed correctly into this tree:

```
      (-)
     /   \
   (-)    2
  /   \
 8     4
```

Which is evaluated to `(8 - 4) - 2 == 2`.